### PR TITLE
fix: README session table not updating after session #70

### DIFF
--- a/src/journal.ts
+++ b/src/journal.ts
@@ -195,7 +195,7 @@ export function updateReadmeSessionsTable(entries: JournalEntry[]): void {
 
   const tableHeader = "| # | Date | Bias | Setups | Confidence | Rule Δ |";
   const tableSep    = "| - | ---- | ---- | ------ | ---------- | ------ |";
-  const tableEnd    = "*This table will be updated automatically each session.*";
+  const tableEnd    = "*This table is updated automatically each session.*";
 
   const startIdx = readme.indexOf(tableHeader);
   const endIdx   = readme.indexOf(tableEnd);


### PR DESCRIPTION
## Summary
- The README redesign changed the table footer text from `*This table will be updated automatically each session.*` to `*This table is updated automatically each session.*`
- `updateReadmeSessionsTable()` in journal.ts still looked for the old string
- The marker mismatch caused the function to silently return, freezing the table at session #70

## Fix
One-line change: update the `tableEnd` marker in journal.ts to match the current README text.

## Test plan
- [x] All 321 tests pass
- [x] TypeScript compiles clean
- [ ] Next session after merge should auto-update the table to show all sessions through #84+

Fixes #26