### PR TITLE
fix(journal): include new rules in reflection.ruleUpdates

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -470,13 +470,24 @@ export async function runAxiomReflection(
 
   const parsed = parseAxiomResponse(rawText, sessionNumber, currentRules, oracle);
 
+  // Map newRules into ruleUpdates so the journal renders them correctly.
+  // evolveMemory writes both ruleUpdates and newRules to the JSON, but only
+  // ruleUpdates was being stored on the reflection — causing "No rule changes
+  // this session" even when new rules were added.
+  const newRuleEntries: RuleUpdate[] = (parsed.newRules ?? []).map((nr: any) => ({
+    ruleId: nr.id,
+    type:   "add" as const,
+    after:  nr.description,
+    reason: nr.reason ?? "New rule added",
+  }));
+
   const reflection: AxiomReflection = {
     timestamp:               new Date(),
     sessionId:               oracle.sessionId,
     whatWorked:              parsed.whatWorked       ?? "",
     whatFailed:              parsed.whatFailed       ?? "",
     cognitiveBiases:         parsed.cognitiveBiases  ?? [],
-    ruleUpdates:             parsed.ruleUpdates      ?? [],
+    ruleUpdates:             [...(parsed.ruleUpdates ?? []), ...newRuleEntries],
     newSystemPromptSections: parsed.systemPromptAdditions ?? "",
     evolutionSummary:        parsed.evolutionSummary ?? "",
   };


### PR DESCRIPTION
## Summary

- `newRules` added by AXIOM were written to `analysis-rules.json` via `evolveMemory` but never merged into the `reflection` object
- The journal and `noChangeStreak` counter both read from `reflection.ruleUpdates`, so sessions that only added new rules were falsely reported as **"No rule changes this session"** and counted toward the stagnation alert
- Confirmed against session #143: `r036` appears in the JSON with `addedSession: 143`, but the journal said "No rule changes this session"

## Fix

In `runAxiomReflection` (`axiom.ts`), map `parsed.newRules` into `RuleUpdate` entries with `type: "add"` and merge them into `reflection.ruleUpdates` before constructing the reflection object.

No other files changed — `"add"` was already a valid `RuleUpdate` type, the HTML CSS already styled `.rule-type.add { color: var(--green) }`, and the markdown template already handles `u.type.toUpperCase()` and `u.after`.

## Side effects fixed

- Journal titles now correctly say "rule evolution" for sessions that added new rules
- `noChangeStreak` no longer counts new-rule sessions as stagnation — stagnation alert won't fire falsely after new rule additions