### PR TITLE
fix(validate): warn on implausible R:R > 20

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -246,6 +246,9 @@ export function validateOracleOutput(
       if (s.RR != null && (typeof s.RR !== "number" || s.RR <= 0)) {
         errors.push(`${label}: RR must be a positive number (got ${s.RR})`);
       }
+      if (s.RR != null && typeof s.RR === "number" && s.RR > 20) {
+        warnings.push(`${label}: implausible RR of ${s.RR} — likely a decimal point error in entry, stop, or target`);
+      }
 
       // Timeframe string
       if (s.timeframe != null && typeof s.timeframe !== "string") {

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -178,6 +178,35 @@ describe("validateOracleOutput", () => {
     expect(result.warnings.some((w) => w.includes("bearish but stop"))).toBe(true);
   });
 
+  it("warns on implausibly high R:R (>20) indicating likely decimal error", () => {
+    // Reproduces session #143 AUD/USD bug: entry 0.7073, target 1.715 → RR 159.95
+    const result = validateOracleOutput(
+      makeOracle({
+        setups: [{
+          instrument: "AUD/USD", type: "MSS", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 0.7073, stop: 0.701, target: 1.715, RR: 159.95, timeframe: "1H",
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("implausible") && w.includes("RR"))).toBe(true);
+  });
+
+  it("does not warn on a legitimate high R:R up to 20", () => {
+    const result = validateOracleOutput(
+      makeOracle({
+        setups: [{
+          instrument: "Gold", type: "FVG", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 2000, stop: 1990, target: 2200, RR: 20, timeframe: "1H",
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("implausible") && w.includes("RR"))).toBe(false);
+  });
+
   // ── Recycled analysis detection ──
 
   it("warns when analysis is >80% similar to previous session", () => {


### PR DESCRIPTION
## Summary

- Session #143 produced an AUD/USD setup with entry `0.7073`, target `1.715`, R:R `159.95` — a clear decimal point error
- The existing RR check only validated `> 0`, so the implausible value passed the validation gate silently
- Adds an upper-bound warning for `RR > 20` with a message indicating a likely decimal error in entry, stop, or target

## Test plan

- [x] Failing test written first (reproduces the session #143 AUD/USD case with RR 159.95)
- [x] Boundary test: RR = 20 does not warn, RR = 159.95 warns
- [x] All 69 validate tests passing
- [x] `tsc --noEmit` clean