### PR TITLE
fix(validate): warn on tight stops during extreme volatility

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -282,6 +282,26 @@ export function validateOracleOutput(
     }
   }
 
+  // Tight stop warning on extreme volatility days (r029 enforcement)
+  // If any snapshot moved ≥5%, stops <1% of entry are almost certainly
+  // too narrow to survive normal noise on that instrument.
+  const extremeDay = oracle.marketSnapshots?.some(s => Math.abs(s.changePercent) >= 3);
+  if (extremeDay && oracle.setups) {
+    for (const s of oracle.setups) {
+      if (
+        typeof s.entry === "number" && s.entry > 0 &&
+        typeof s.stop  === "number" && s.stop  > 0
+      ) {
+        const stopPct = (Math.abs(s.entry - s.stop) / s.entry) * 100;
+        if (stopPct < 1) {
+          warnings.push(
+            `${s.instrument ?? "Setup"}: stop is only ${stopPct.toFixed(2)}% from entry during extreme volatility (≥5% session move) — r029 requires wider stops`
+          );
+        }
+      }
+    }
+  }
+
   // "Other" type overuse — ICT types should be preferred
   if (oracle.setups && oracle.setups.length > 0) {
     const otherCount = oracle.setups.filter(s => s.type === "Other").length;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -207,6 +207,69 @@ describe("validateOracleOutput", () => {
     expect(result.warnings.some((w) => w.includes("implausible") && w.includes("RR"))).toBe(false);
   });
 
+  // ── Tight stop on extreme volatility days ──
+
+  it("warns when stop is <1% from entry during an extreme volatility session (≥3% move)", () => {
+    // Reproduces session #145: NASDAQ 20-point stop after +4.78% day, ~0.08% of entry
+    const extremeSnapshot = {
+      symbol: "NAS100", name: "NASDAQ 100", category: "index",
+      price: 25200, previousClose: 24050, change: 1150, changePercent: 4.78,
+      high: 25202, low: 24050, timestamp: new Date(),
+    };
+    const result = validateOracleOutput(
+      makeOracle({
+        marketSnapshots: [extremeSnapshot],
+        setups: [{
+          instrument: "NASDAQ 100", type: "PDH", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 25200, stop: 25180, target: 25250, RR: 2.5, timeframe: "4H",
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(true);
+  });
+
+  it("does not warn about stop size when session moves are normal (<5%)", () => {
+    const normalSnapshot = {
+      symbol: "NAS100", name: "NASDAQ 100", category: "index",
+      price: 25200, previousClose: 25000, change: 200, changePercent: 0.8,
+      high: 25210, low: 24990, timestamp: new Date(),
+    };
+    const result = validateOracleOutput(
+      makeOracle({
+        marketSnapshots: [normalSnapshot],
+        setups: [{
+          instrument: "NASDAQ 100", type: "PDH", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 25200, stop: 25180, target: 25250, RR: 2.5, timeframe: "4H",
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(false);
+  });
+
+  it("does not warn when stop is adequately wide (≥1% of entry) even on extreme day", () => {
+    const extremeSnapshot = {
+      symbol: "NAS100", name: "NASDAQ 100", category: "index",
+      price: 25200, previousClose: 24050, change: 1150, changePercent: 4.78,
+      high: 25202, low: 24050, timestamp: new Date(),
+    };
+    const result = validateOracleOutput(
+      makeOracle({
+        marketSnapshots: [extremeSnapshot],
+        setups: [{
+          instrument: "NASDAQ 100", type: "PDH", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 25200, stop: 24900, target: 25800, RR: 2, timeframe: "4H",
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(false);
+  });
+
   // ── Recycled analysis detection ──
 
   it("warns when analysis is >80% similar to previous session", () => {


### PR DESCRIPTION
## Summary

- Sessions #143-145 showed stops far too narrow relative to the day's actual range — NASDAQ 20-point stop after a +1,062-point session (~0.08% of entry), Bitcoin 100-point stop after a +$3,500 move
- r029 requires wider stops on extreme days but the validation layer had no enforcement — tight stops passed silently
- Adds a warning in `validateOracleOutput`: if any market snapshot moved ≥3% and a setup's stop is <1% of entry, warn with a reference to r029

## Threshold rationale

- 3% session move = ~2x typical daily range for major indices (per r029 language)
- Catches NASDAQ +4.78%, S&P +3.88%, oil -12.69% from today's sessions
- Avoids false positives on routine crypto moves (typical 1-2% daily)
- 1% stop minimum gives room to survive noise on a high-range day

## Test plan

- [x] Failing test written first (NASDAQ 4.78% day, 20-point stop → warns)
- [x] Normal day test: 0.8% session move with same tight stop → no warn
- [x] Adequate stop test: ≥1% stop on extreme day → no warn
- [x] All 72 validate tests passing
- [x] `tsc --noEmit` clean