### PR TITLE
chore(ci): upgrade actions to v5, Node 22 LTS

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`  
- `node-version: '20'` → `'22'` (Node 22 LTS, current stable)

Node.js 20 support in the v4 actions is deprecated September 2026. Routine upgrade with no functional changes to the session pipeline.