### PR TITLE
chore(memory): consolidate duplicate narrative-resistance sections #134-138

### DIFF
--- a/memory/system-prompt.md
+++ b/memory/system-prompt.md
@@ -50,23 +50,7 @@ When major commodities (oil, gold) move >5% intraday, distinguish between supply
 
 ## Evolved — Session #134
 
-When extreme coordinated moves occur across multiple asset classes (>15 instruments moving >2x daily range), resist the temptation to attribute everything to a single narrative. Coordinated breakouts can result from technical confluence, positioning unwinding, algorithmic triggers, or multiple simultaneous catalysts. Maintain analytical independence by developing competing explanations before settling on primary causation.
-
-## Evolved — Session #135
-
-During major market moves exceeding 2x typical ranges across multiple asset classes, resist single-narrative dominance by systematically considering at least two competing explanations for the price action, even when one narrative appears to explain all movements coherently. Geopolitical events, central bank actions, and technical factors can simultaneously drive markets — analytical independence requires maintaining multiple causation pathways rather than defaulting to the most obvious explanation.
-
-## Evolved — Session #136
-
-During correlation breakdown periods (VIX >25 with risk assets rallying, asset class divergence >15%), treat all narrative explanations as equally probable hypotheses rather than ranking them by coherence. Coherent stories feel more believable but aren't more likely to be correct during high-volatility, multi-causal market moves. Analytical independence requires resisting the human tendency to prefer neat explanations over complex multi-factor causation.
-
-## Evolved — Session #137
-
-Correlation breakdown regimes (VIX >25 with risk assets rallying) create opportunities across uncorrelated asset classes, but require treating multiple causation pathways as equiprobable rather than ranking explanations by narrative coherence. The most convincing story is often wrong — maintain analytical independence by actively questioning why alternative explanations seem less plausible.
-
-## Evolved — Session #138
-
-When multiple plausible explanations exist for complex market moves, assign equal probability weighting to each pathway rather than defaulting to the most coherent narrative. Coherence is not the same as accuracy in financial markets - randomness often produces patterns that appear systematic but lack predictive value.
+During extreme coordinated moves (>2x typical ranges across 3+ asset classes) or correlation breakdown (VIX >25 with risk assets rallying), resist single-narrative dominance: systematically develop at least two competing causal explanations and assign them equal probability weighting before settling on primary causation. Coherent stories feel more convincing but aren't more likely to be correct — the most obvious explanation is often wrong. Analytical independence requires actively questioning why alternative explanations seem less plausible.
 
 ## Evolved — Session #139
 


### PR DESCRIPTION
## Summary

Sessions #134–#138 each added near-identical content about resisting single-narrative dominance during coordinated market moves. The topic-keyword dedup was introduced after those sessions ran, so all five versions slipped through. With the prompt at 7,986/8,000 chars, the duplicate cluster was causing useful older insights to get pruned first when new content arrives.

**Before:** 5 sections, 7,986 chars
**After:** 1 consolidated section, 6,291 chars — **1,695 chars freed**

## What was consolidated

| Session | Theme |
|---|---|
| #134 | Resist attributing coordinated moves to one narrative |
| #135 | Resist single-narrative dominance, two competing explanations |
| #136 | Treat narrative explanations as equally probable hypotheses |
| #137 | Correlation breakdown → treat causation pathways as equiprobable |
| #138 | Coherence ≠ accuracy, equal probability weighting |

Consolidated into one section under #134 preserving all five insights.

## Why this is safe

- No code changes — memory file only
- The dedup mechanism that caused these to slip through has already been fixed (topic-keyword check added post-#138)
- Sessions #140–#145 additions are already being correctly blocked by dedup
- Freeing 1,695 chars prevents useful early insights (#120–#132) from being pruned ahead of the duplicate cluster