### PR TITLE
fix(actions): use NEXUS_PAT to bypass branch protection for bot commits

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NEXUS_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -81,6 +81,8 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
 
       - name: Commit memory & journal to main
+        env:
+          NEXUS_PAT: ${{ secrets.NEXUS_PAT }}
         run: |
           git config user.name "NEXUS"
           git config user.email "nexus-bot@users.noreply.github.com"
@@ -100,6 +102,11 @@ jobs:
             git stash push -- src/
           else
             echo "FORGE_CHANGED=false" >> "$GITHUB_ENV"
+          fi
+
+          # Use NEXUS_PAT to bypass branch protection for bot commits (falls back to GITHUB_TOKEN)
+          if [ -n "$NEXUS_PAT" ]; then
+            git remote set-url origin "https://x-access-token:${NEXUS_PAT}@github.com/${{ github.repository }}"
           fi
 
           # Commit memory/journal/docs/README to main (always)


### PR DESCRIPTION
## Problem

Scheduled NEXUS sessions (sessions #146+) are completing ORACLE/AXIOM/journal work successfully but failing at the final `git push` step with:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Branch protection was tightened during the April 10 dev session to require PRs, which broke the workflow's direct push to main.

## Fix

- Checkout uses `NEXUS_PAT` if set, falls back to `GITHUB_TOKEN`  
- Before pushing memory/journal commits, the remote URL is rewritten to use `NEXUS_PAT` (which, as a PAT from an admin user, can bypass branch protection)
- If `NEXUS_PAT` is not set the workflow behaves exactly as before

## Required action before merging

1. Go to **github.com → Settings → Developer settings → Personal access tokens**
2. Create a classic PAT with `repo` scope (or fine-grained with Contents: read+write)
3. Add it as a repo secret named **`NEXUS_PAT`** under **Settings → Secrets → Actions**

Once the secret exists and this PR is merged, scheduled sessions will push memory/journal commits directly to main again.

## Alternative (no secrets needed)

If you prefer not to use a PAT:  
Settings → Branches → Edit `main` rule → **"Allow specified actors to bypass required pull requests"** → add `github-actions[bot]`