### PR TITLE
feat(validate): warn when confidence >55% produces fewer than 3 setups (r026)

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -302,6 +302,19 @@ export function validateOracleOutput(
     }
   }
 
+  // r026: high confidence must produce broad setup coverage
+  // When confidence > 55%, fewer than 3 setups indicates incomplete screening.
+  // Analytics show this is the most common cause of hit rate underperformance
+  // in the 50-85% confidence bands.
+  if (typeof oracle.confidence === "number" && oracle.confidence > 55) {
+    const setupCount = oracle.setups?.length ?? 0;
+    if (setupCount < 3) {
+      warnings.push(
+        `r026: confidence ${oracle.confidence}% with only ${setupCount} setup(s) — high-confidence sessions require systematic screening across all available instruments (minimum 3 setups)`
+      );
+    }
+  }
+
   // "Other" type overuse — ICT types should be preferred
   if (oracle.setups && oracle.setups.length > 0) {
     const otherCount = oracle.setups.filter(s => s.type === "Other").length;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -320,6 +320,56 @@ describe("validateOracleOutput", () => {
     );
     expect(result.warnings.some((w) => w.includes("Recycled"))).toBe(false);
   });
+
+  // ── Insufficient setup count (r026 enforcement) ──
+
+  function makeValidSetup(instrument: string) {
+    return {
+      instrument, type: "FVG" as const, direction: "bullish" as const,
+      description: "test", invalidation: "test",
+      entry: 1.3, stop: 1.28, target: 1.34, RR: 2, timeframe: "1H",
+    };
+  }
+
+  it("warns when confidence > 55 and only 1 setup produced (r026)", () => {
+    const result = validateOracleOutput(
+      makeOracle({ confidence: 72, setups: [makeValidSetup("AUD/USD")] }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r026"))).toBe(true);
+  });
+
+  it("warns when confidence > 55 and 2 setups produced (r026)", () => {
+    const result = validateOracleOutput(
+      makeOracle({ confidence: 60, setups: [makeValidSetup("EUR/USD"), makeValidSetup("GBP/USD")] }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r026"))).toBe(true);
+  });
+
+  it("does not warn when confidence > 55 with 3 setups", () => {
+    const result = validateOracleOutput(
+      makeOracle({ confidence: 72, setups: [makeValidSetup("EUR/USD"), makeValidSetup("GBP/USD"), makeValidSetup("AUD/USD")] }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r026"))).toBe(false);
+  });
+
+  it("does not warn when confidence <= 55 with 1 setup", () => {
+    const result = validateOracleOutput(
+      makeOracle({ confidence: 45, setups: [makeValidSetup("AUD/USD")] }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r026"))).toBe(false);
+  });
+
+  it("does not warn when confidence exactly 55 with 1 setup", () => {
+    const result = validateOracleOutput(
+      makeOracle({ confidence: 55, setups: [makeValidSetup("AUD/USD")] }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r026"))).toBe(false);
+  });
 });
 
 // ── extractConfidenceFromText ────────────────────────────────


### PR DESCRIPTION
## Problem

Analytics show NEXUS is severely overconfident in the 50–85% confidence bands:

| Range | Claimed | Actual Hit Rate | Delta |
|-------|---------|-----------------|-------|
| 50–70% | 57% | 31.4% | **−26pp** |
| 70–85% | 73% | 42.4% | **−30pp** |

A key driver is high-confidence sessions producing too few setups — session #143 reported 72% confidence but generated only 1 setup (R:R 159.95 decimal error). r026 explicitly requires systematic screening across all available instruments at high confidence, but there was no enforcement.

## Fix

Added a warning in `validateOracleOutput` when `confidence > 55` and `setups.length < 3`:

```
r026: confidence 72% with only 1 setup(s) — high-confidence sessions require
systematic screening across all available instruments (minimum 3 setups)
```

This warning surfaces in the AXIOM context so the next session self-corrects.

## Tests

5 new tests added (77 total, all passing):
- Warns at confidence 72 with 1 setup ✅
- Warns at confidence 60 with 2 setups ✅
- No warn at confidence 72 with 3 setups ✅
- No warn at confidence 45 with 1 setup ✅
- No warn at boundary (exactly 55) with 1 setup ✅

## Backlog

Closes the "insufficient setup count warning" item.