### PR TITLE
fix(workflow): conflict-resistant commit step for concurrent sessions

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -86,10 +86,24 @@ jobs:
         run: |
           git config user.name "NEXUS"
           git config user.email "nexus-bot@users.noreply.github.com"
-          git pull --rebase --autostash origin main
+
+          # Use NEXUS_PAT to bypass branch protection for bot commits (falls back to GITHUB_TOKEN)
+          if [ -n "$NEXUS_PAT" ]; then
+            git remote set-url origin "https://x-access-token:${NEXUS_PAT}@github.com/${{ github.repository }}"
+          fi
 
           # Safety: revert any changes to protected files that shouldn't be modified by sessions
           git checkout HEAD -- NEXUS_IDENTITY.md 2>/dev/null || true
+
+          # Save our new session entry BEFORE pulling so we can re-apply it if
+          # the autostash pop conflicts (happens when two sessions run concurrently)
+          node -e "
+            const fs = require('fs');
+            const sessions = JSON.parse(fs.readFileSync('./memory/sessions.json', 'utf8'));
+            const entry = sessions[sessions.length - 1];
+            fs.writeFileSync('/tmp/nexus-new-session.json', JSON.stringify(entry));
+            console.log('Saved session entry:', entry.sessionId);
+          " || true
 
           # Check if FORGE changed any src/ files
           FORGE_CHANGES=$(git diff --name-only src/ 2>/dev/null || true)
@@ -104,10 +118,43 @@ jobs:
             echo "FORGE_CHANGED=false" >> "$GITHUB_ENV"
           fi
 
-          # Use NEXUS_PAT to bypass branch protection for bot commits (falls back to GITHUB_TOKEN)
-          if [ -n "$NEXUS_PAT" ]; then
-            git remote set-url origin "https://x-access-token:${NEXUS_PAT}@github.com/${{ github.repository }}"
-          fi
+          # Pull remote changes. If the autostash pop conflicts (two concurrent
+          # sessions both modified sessions.json / docs/index.html), resolve below.
+          git pull --rebase --autostash origin main || {
+            echo "Autostash pop conflicted — resolving..."
+
+            # sessions.json: get the clean remote version via bash (no execSync),
+            # then re-append our session entry using node for JSON safety.
+            if grep -ql "^<<<<<<" memory/sessions.json 2>/dev/null; then
+              git show origin/main:memory/sessions.json > /tmp/remote-sessions.json 2>/dev/null
+              node -e "
+                const fs = require('fs');
+                const remote = JSON.parse(fs.readFileSync('/tmp/remote-sessions.json', 'utf8'));
+                const entry = JSON.parse(fs.readFileSync('/tmp/nexus-new-session.json', 'utf8'));
+                if (!remote.some(function(s) { return s.sessionId === entry.sessionId; })) {
+                  remote.push(entry);
+                  console.log('Re-appended session:', entry.sessionId);
+                } else {
+                  console.log('Session already in remote:', entry.sessionId);
+                }
+                fs.writeFileSync('./memory/sessions.json', JSON.stringify(remote, null, 2));
+              "
+              git add memory/sessions.json
+            fi
+
+            # docs/index.html: take theirs — we always rebuild it below anyway
+            if grep -ql "^<<<<<<" docs/index.html 2>/dev/null; then
+              git checkout --theirs docs/index.html 2>/dev/null || true
+              git add docs/index.html
+            fi
+
+            # Drop the unresolved autostash
+            git stash drop 2>/dev/null || true
+          }
+
+          # Always rebuild HTML from the current sessions.json — ensures the page
+          # is consistent regardless of whether a conflict occurred
+          npm run rebuild-site
 
           # Commit memory/journal/docs/README to main (always)
           git add memory/ journal/ docs/ README.md


### PR DESCRIPTION
## Problem

Two manual workflow triggers fired within seconds of each other. Both sessions ran to completion (ORACLE/AXIOM/journal), then both tried to push to main. The second run's `git pull --rebase --autostash` failed because both sessions appended different data to `sessions.json` and regenerated `docs/index.html`. The stash pop couldn't auto-merge these files, leaving conflict markers (`<<<<<<<`) committed to main — required manual hotfix (PR #43).

## Root cause

`sessions.json` is a large JSON array. Two concurrent appends produce a conflict git cannot resolve automatically. `docs/index.html` is fully regenerated each session, producing the same problem.

## Fix

Three changes to the commit step:

1. **Save session entry before pulling** — writes the new session to `/tmp/nexus-new-session.json` so it can be re-applied even if the pull overwrites `sessions.json`

2. **Conflict resolution on autostash pop failure:**
   - `sessions.json`: fetch clean remote version via `git show origin/main:...` (bash, no `execSync`), re-append our new entry with node (pure file I/O), mark resolved
   - `docs/index.html`: take `--theirs` (we rebuild it anyway), mark resolved
   - Drop the unresolved autostash

3. **Always rebuild HTML after pull** — `npm run rebuild-site` runs unconditionally so `docs/index.html` always reflects the current `sessions.json`, whether or not a conflict occurred

## Result

Concurrent session runs now produce a clean merge:
- All session entries are preserved in `sessions.json`
- `docs/index.html` is rebuilt from the complete session list
- No conflict markers reach main