### PR TITLE
fix(workflow): resolve analysis-rules.json concurrent session conflicts

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -105,6 +105,10 @@ jobs:
             console.log('Saved session entry:', entry.sessionId);
           " || true
 
+          # Save current analysis-rules.json BEFORE pulling so we can merge it
+          # if the autostash pop conflicts with a concurrent session's version
+          cp memory/analysis-rules.json /tmp/nexus-local-rules.json 2>/dev/null || true
+
           # Check if FORGE changed any src/ files
           FORGE_CHANGES=$(git diff --name-only src/ 2>/dev/null || true)
 
@@ -140,6 +144,17 @@ jobs:
                 fs.writeFileSync('./memory/sessions.json', JSON.stringify(remote, null, 2));
               "
               git add memory/sessions.json
+            fi
+
+            # analysis-rules.json: merge remote + local using the dedicated script.
+            # Remote is taken as the base; local rule changes are applied on top
+            # (new rules added, rules with higher lastModifiedSession win).
+            if grep -ql "^<<<<<<" memory/analysis-rules.json 2>/dev/null; then
+              git show origin/main:memory/analysis-rules.json > /tmp/nexus-remote-rules.json 2>/dev/null
+              node scripts/merge-analysis-rules.js /tmp/nexus-remote-rules.json /tmp/nexus-local-rules.json > /tmp/nexus-merged-rules.json
+              cp /tmp/nexus-merged-rules.json memory/analysis-rules.json
+              echo "Merged analysis-rules.json (concurrent session conflict resolved)"
+              git add memory/analysis-rules.json
             fi
 
             # docs/index.html: take theirs — we always rebuild it below anyway

--- a/scripts/merge-analysis-rules.js
+++ b/scripts/merge-analysis-rules.js
@@ -1,0 +1,82 @@
+// ============================================================
+// NEXUS — Analysis Rules Merge Utility
+// Merges two analysis-rules.json versions produced by concurrent
+// sessions. Used by the GitHub Actions commit step to resolve
+// autostash conflicts without losing either session's rule changes.
+//
+// Usage (CLI): node scripts/merge-analysis-rules.js <remote.json> <local.json>
+// Outputs merged JSON to stdout.
+//
+// Usage (module): const { mergeAnalysisRules } = require('./merge-analysis-rules')
+// ============================================================
+
+"use strict";
+
+/**
+ * Merges two analysis-rules.json objects.
+ *
+ * Strategy:
+ * - Rules: start with remote as base; for each rule in local,
+ *   add it if new, or replace if local has a higher lastModifiedSession.
+ * - version: take the higher of the two.
+ * - lastUpdated: take the later ISO timestamp.
+ * - sessionNotes / focusInstruments: taken from whichever has the higher version.
+ *
+ * @param {object} remote - The version already on origin/main
+ * @param {object} local  - The version written by the current session
+ * @returns {object} merged rules object
+ */
+function mergeAnalysisRules(remote, local) {
+  // Build map of remote rules by ID
+  const byId = {};
+  for (const rule of (remote.rules || [])) {
+    byId[rule.id] = rule;
+  }
+
+  // Apply local rules
+  for (const rule of (local.rules || [])) {
+    const existing = byId[rule.id];
+    if (!existing) {
+      byId[rule.id] = rule;
+    } else if ((rule.lastModifiedSession ?? 0) > (existing.lastModifiedSession ?? 0)) {
+      byId[rule.id] = rule;
+    }
+    // else keep remote version (it's more recent or equal)
+  }
+
+  // Sort by numeric ID (r001, r002, … r037)
+  const mergedRules = Object.values(byId).sort((a, b) => {
+    const numA = parseInt(a.id.replace(/\D/g, ""), 10) || 0;
+    const numB = parseInt(b.id.replace(/\D/g, ""), 10) || 0;
+    return numA - numB;
+  });
+
+  const higherVersion = (local.version ?? 0) >= (remote.version ?? 0) ? local : remote;
+
+  return {
+    ...remote,
+    rules: mergedRules,
+    version: Math.max(remote.version ?? 0, local.version ?? 0),
+    lastUpdated: (local.lastUpdated ?? "") > (remote.lastUpdated ?? "")
+      ? local.lastUpdated
+      : remote.lastUpdated,
+    sessionNotes: higherVersion.sessionNotes ?? remote.sessionNotes,
+    focusInstruments: higherVersion.focusInstruments ?? remote.focusInstruments,
+  };
+}
+
+module.exports = { mergeAnalysisRules };
+
+// CLI entry point
+if (require.main === module) {
+  const fs = require("fs");
+  const [, , remotePath, localPath] = process.argv;
+  if (!remotePath || !localPath) {
+    console.error("Usage: node scripts/merge-analysis-rules.js <remote.json> <local.json>");
+    process.exit(1);
+  }
+  const remote = JSON.parse(fs.readFileSync(remotePath, "utf8"));
+  const local  = JSON.parse(fs.readFileSync(localPath,  "utf8"));
+  const merged = mergeAnalysisRules(remote, local);
+  process.stdout.write(JSON.stringify(merged, null, 2) + "\n");
+}

--- a/tests/merge-analysis-rules.test.ts
+++ b/tests/merge-analysis-rules.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { mergeAnalysisRules } from "../scripts/merge-analysis-rules";
+
+const baseRule = (id: string, mod: number, desc = "base") => ({
+  id,
+  category: "test",
+  description: desc,
+  weight: 5,
+  addedSession: 1,
+  lastModifiedSession: mod,
+});
+
+describe("mergeAnalysisRules", () => {
+  it("keeps all rules from remote when local has no changes", () => {
+    const remote = {
+      rules: [baseRule("r001", 0), baseRule("r002", 0)],
+      version: 10,
+      lastUpdated: "2026-04-11T13:07:00.000Z",
+      sessionNotes: "Session #146",
+      focusInstruments: ["BTC"],
+    };
+    const local = structuredClone(remote);
+
+    const merged = mergeAnalysisRules(remote, local);
+    expect(merged.rules).toHaveLength(2);
+    expect(merged.rules.map((r: any) => r.id)).toEqual(["r001", "r002"]);
+  });
+
+  it("adds new rules from local that don't exist in remote", () => {
+    const remote = {
+      rules: [baseRule("r001", 0)],
+      version: 10,
+      lastUpdated: "2026-04-11T13:07:00.000Z",
+      sessionNotes: "Session #146a",
+      focusInstruments: ["BTC"],
+    };
+    const local = {
+      ...remote,
+      rules: [baseRule("r001", 0), baseRule("r002", 147, "new rule from local")],
+      version: 11,
+      lastUpdated: "2026-04-11T13:08:00.000Z",
+      sessionNotes: "Session #147",
+    };
+
+    const merged = mergeAnalysisRules(remote, local);
+    expect(merged.rules).toHaveLength(2);
+    expect(merged.rules.find((r: any) => r.id === "r002")).toBeDefined();
+  });
+
+  it("keeps remote version of a rule when remote has a more recent modification", () => {
+    const remote = {
+      rules: [baseRule("r001", 148, "remote newer")],
+      version: 12,
+      lastUpdated: "2026-04-11T14:00:00.000Z",
+      sessionNotes: "Session #148",
+      focusInstruments: ["BTC"],
+    };
+    const local = {
+      ...remote,
+      rules: [baseRule("r001", 147, "local older")],
+      version: 11,
+      lastUpdated: "2026-04-11T13:08:00.000Z",
+      sessionNotes: "Session #147",
+    };
+
+    const merged = mergeAnalysisRules(remote, local);
+    expect(merged.rules[0].description).toBe("remote newer");
+  });
+
+  it("takes local version of a rule when local has a more recent modification", () => {
+    const remote = {
+      rules: [baseRule("r001", 146, "remote older")],
+      version: 10,
+      lastUpdated: "2026-04-11T13:07:00.000Z",
+      sessionNotes: "Session #146",
+      focusInstruments: ["BTC"],
+    };
+    const local = {
+      ...remote,
+      rules: [baseRule("r001", 147, "local newer")],
+      version: 11,
+      lastUpdated: "2026-04-11T13:08:00.000Z",
+      sessionNotes: "Session #147",
+    };
+
+    const merged = mergeAnalysisRules(remote, local);
+    expect(merged.rules[0].description).toBe("local newer");
+  });
+
+  it("takes the higher version number", () => {
+    const remote = { rules: [], version: 87, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "", focusInstruments: [] };
+    const local  = { rules: [], version: 88, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "", focusInstruments: [] };
+    expect(mergeAnalysisRules(remote, local).version).toBe(88);
+    expect(mergeAnalysisRules(local, remote).version).toBe(88);
+  });
+
+  it("takes the later lastUpdated timestamp", () => {
+    const remote = { rules: [], version: 87, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "", focusInstruments: [] };
+    const local  = { rules: [], version: 87, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "", focusInstruments: [] };
+    expect(mergeAnalysisRules(remote, local).lastUpdated).toBe("2026-04-11T13:08:00.000Z");
+    expect(mergeAnalysisRules(local, remote).lastUpdated).toBe("2026-04-11T13:08:00.000Z");
+  });
+
+  it("takes sessionNotes from the session with the higher version", () => {
+    const remote = { rules: [], version: 87, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "Session #146a", focusInstruments: [] };
+    const local  = { rules: [], version: 88, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "Session #147",  focusInstruments: [] };
+    expect(mergeAnalysisRules(remote, local).sessionNotes).toBe("Session #147");
+  });
+
+  it("produces valid sorted rule order by numeric ID", () => {
+    const remote = { rules: [baseRule("r003", 0), baseRule("r001", 0)], version: 10, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "", focusInstruments: [] };
+    const local  = { rules: [baseRule("r002", 147)], version: 11, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "", focusInstruments: [] };
+    const ids = mergeAnalysisRules(remote, local).rules.map((r: any) => r.id);
+    expect(ids).toEqual(["r001", "r002", "r003"]);
+  });
+
+  it("output is valid JSON", () => {
+    const remote = { rules: [baseRule("r001", 0)], version: 10, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "a", focusInstruments: ["BTC"] };
+    const local  = { rules: [baseRule("r001", 147), baseRule("r002", 147)], version: 11, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "b", focusInstruments: ["ETH"] };
+    const merged = mergeAnalysisRules(remote, local);
+    expect(() => JSON.parse(JSON.stringify(merged))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Two sessions running simultaneously could both write \`memory/analysis-rules.json\`, then conflict during \`git pull --rebase --autostash\`. Git left merge conflict markers inside the JSON, which broke \`JSON.parse()\` on the next session start — root cause of the **2026-04-12 outage**.

PR #44 fixed \`sessions.json\` and \`docs/index.html\` but missed \`analysis-rules.json\`.

## Changes

- **\`scripts/merge-analysis-rules.js\`** — merge utility: remote as base, local new rules added, higher \`lastModifiedSession\` wins for conflicts, higher version/later timestamp kept
- **\`tests/merge-analysis-rules.test.ts\`** — 9 unit tests covering all merge scenarios
- **\`.github/workflows/session.yml\`** — save rules to \`/tmp\` before pull; detect conflict markers and resolve via merge script in the \`autostash || {\` handler

## Test plan

- [x] 9 unit tests pass
- [x] Full suite: 402 tests passing
- [x] \`tsc --noEmit\` clean
- [ ] Monitor next concurrent session pair for "Merged analysis-rules.json" log line