### PR TITLE
fix(validate): hard-filter r029 stop violations and detect AXIOM rumination

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -26,7 +26,7 @@ import {
   loadAllJournalEntries,
   saveJournalEntry,
 } from "./journal";
-import { validateOracleOutput, validateWeekendCryptoScreening, logFailure, loadRecentFailures } from "./validate";
+import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, logFailure, loadRecentFailures } from "./validate";
 import { buildAnalyticsSummary }                                    from "./analytics";
 import { fetchRSSNews, formatRSSForPrompt }                          from "./rss";
 import { notifySessionComplete }                                     from "./notifications";
@@ -525,6 +525,15 @@ export async function runAndValidateOracle(
     const err = new Error("ORACLE validation failed");
     (err as any).oracleValidationFailure = true;
     throw err;
+  }
+
+  // Filter setups that violate r029 stop distance requirements
+  const { oracle: filteredOracle, removed: removedSetups } = filterNonCompliantSetups(oracle);
+  if (removedSetups.length > 0) {
+    for (const r of removedSetups) {
+      console.warn(`  ⚠ r029: removed setup [${r.instrument}] — ${r.reason}`);
+    }
+    oracle = filteredOracle;
   }
 
   // Print brief summary

--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -6,7 +6,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { createSelfTask, closeSelfTask, SelfTask } from "./self-tasks";
 import { sanitizeAxiomOutput, getMaxOutputTokens, getMaxSystemPromptLength } from "./security";
-import { validateAxiomOutput, logFailure, extractConfidenceFromText, calculateTextSimilarity } from "./validate";
+import { validateAxiomOutput, logFailure, extractConfidenceFromText, calculateTextSimilarity, detectAxiomRumination } from "./validate";
 import { loadAllJournalEntries } from "./journal";
 import {
   salvageJSON, stripSurrogates, extractJSONFromResponse,
@@ -385,6 +385,33 @@ export function parseAxiomResponse(
     newSelfTasks:      secResult.newSelfTasks,
     resolvedSelfTasks: secResult.resolvedTasks,
   };
+
+  // Inject a forced self-task when AXIOM acknowledged a compliance violation
+  // but took no action (no rule update, new rule, or self-task). This closes
+  // the rumination blind spot where verbal acknowledgement replaces action.
+  const ruminationWarning = detectAxiomRumination({
+    whatFailed:   rawParsed.whatFailed,
+    ruleUpdates:  parsed.ruleUpdates,
+    newRules:     parsed.newRules,
+    newSelfTasks: parsed.newSelfTasks,
+  });
+  if (ruminationWarning) {
+    const alreadyHasRuleGap = (parsed.newSelfTasks ?? []).some(
+      (t: any) => t.category === "rule-gap"
+    );
+    if (!alreadyHasRuleGap) {
+      console.warn("  ⚠ Axiom: compliance violation acknowledged without action — injecting forced self-task");
+      parsed.newSelfTasks = [
+        ...(parsed.newSelfTasks ?? []),
+        {
+          title: "Enforce stop distance validation at ORACLE output layer (r029)",
+          body: "AXIOM acknowledged a compliance violation but created no rule update or self-task to address it. Add hard filtering in validate.ts to remove setups that violate r029 minimum stop distance requirements during elevated volatility sessions, rather than just warning.",
+          category: "rule-gap",
+          priority: "high",
+        },
+      ];
+    }
+  }
 
   return parsed;
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -374,6 +374,96 @@ export function validateOracleOutput(
   };
 }
 
+// ── r029 Stop Distance Filter ────────────────────────────
+// Hard-removes setups that violate minimum stop distance requirements
+// during elevated volatility. This replaces the warn-only behaviour so
+// ORACLE cannot silently produce non-compliant setups.
+//
+// Thresholds (mirrors r029 wording exactly):
+//   extreme   : any snapshot |changePercent| ≥ 5  → stop must be ≥ 1.5% from entry
+//   moderate  : any snapshot |changePercent| ≥ 3  → stop must be ≥ 1.0% from entry
+//   normal    : no filter applied
+
+export interface SetupRemovalRecord {
+  instrument: string;
+  reason: string;
+}
+
+export function filterNonCompliantSetups(oracle: OracleAnalysis): {
+  oracle: OracleAnalysis;
+  removed: SetupRemovalRecord[];
+} {
+  const snapshots = oracle.marketSnapshots ?? [];
+  const maxMove = snapshots.reduce((max, s) => Math.max(max, Math.abs(s.changePercent)), 0);
+
+  const extremeVolatility = maxMove >= 5;
+  const moderateVolatility = maxMove >= 3;
+
+  if (!extremeVolatility && !moderateVolatility) {
+    return { oracle, removed: [] };
+  }
+
+  const minStopPct = extremeVolatility ? 1.5 : 1.0;
+  const volatilityLabel = extremeVolatility ? "extreme" : "moderate";
+
+  const removed: SetupRemovalRecord[] = [];
+  const compliantSetups: typeof oracle.setups = [];
+
+  for (const s of oracle.setups) {
+    if (
+      typeof s.entry === "number" && s.entry > 0 &&
+      typeof s.stop  === "number" && s.stop  > 0
+    ) {
+      const stopPct = (Math.abs(s.entry - s.stop) / s.entry) * 100;
+      if (stopPct < minStopPct) {
+        removed.push({
+          instrument: s.instrument ?? "unknown",
+          reason: `r029: stop is ${stopPct.toFixed(2)}% from entry — requires ≥${minStopPct}% during ${volatilityLabel} volatility (session move ${maxMove.toFixed(1)}%)`,
+        });
+        continue;
+      }
+    }
+    compliantSetups.push(s);
+  }
+
+  return {
+    oracle: { ...oracle, setups: compliantSetups },
+    removed,
+  };
+}
+
+// ── AXIOM Rumination Detector ─────────────────────────────
+// Detects when AXIOM acknowledges a compliance failure in text but
+// takes zero concrete action (no rule update, new rule, or self-task).
+// Returns a warning string to surface this, or null if no issue.
+
+const VIOLATION_KEYWORDS = [
+  "compliance failure", "compliance violation", "execution gap",
+  "systematic failure", "failed to implement", "failed to comply",
+  "failed to apply", "violation", "non-compliant",
+];
+
+export function detectAxiomRumination(parsed: {
+  whatFailed?: string;
+  ruleUpdates?: any[];
+  newRules?: any[];
+  newSelfTasks?: any[];
+}): string | null {
+  const failText = (parsed.whatFailed ?? "").toLowerCase();
+  if (!failText) return null;
+
+  const hasViolationLanguage = VIOLATION_KEYWORDS.some(kw => failText.includes(kw));
+  if (!hasViolationLanguage) return null;
+
+  const hasRuleUpdate  = (parsed.ruleUpdates  ?? []).length > 0;
+  const hasNewRule     = (parsed.newRules      ?? []).length > 0;
+  const hasSelfTask    = (parsed.newSelfTasks  ?? []).length > 0;
+
+  if (hasRuleUpdate || hasNewRule || hasSelfTask) return null;
+
+  return "AXIOM acknowledged failure without action: compliance failure identified in whatFailed but no rule updates, new rules, or self-tasks were created — a forced self-task will be injected";
+}
+
 // ── Bias-to-Rule Mapping Checker ─────────────────────────
 // Detects when AXIOM identifies cognitive biases but produces no rule updates
 // that address them. Warns so the feedback reaches AXIOM's next context.
@@ -537,6 +627,10 @@ export function validateAxiomOutput(
 
   // Check that detected cognitive biases are addressed by rule changes
   warnings.push(...checkBiasRuleMapping(parsed));
+
+  // Detect unacted compliance violations (rumination blind spot)
+  const ruminationWarning = detectAxiomRumination(parsed);
+  if (ruminationWarning) warnings.push(ruminationWarning);
 
   return {
     valid: errors.length === 0,

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -312,3 +312,56 @@ describe("handleSelfTasks", () => {
     await handleSelfTasks({}, [], 1);
   });
 });
+
+// ── parseAxiomResponse — forced self-task injection ──────────
+
+describe("parseAxiomResponse forced self-task injection", () => {
+  const rules = makeRules();
+
+  it("injects a forced self-task when axiom acknowledges compliance violation without any action", () => {
+    const json = JSON.stringify({
+      whatWorked: "Good cross-asset analysis structure",
+      whatFailed: "Critical compliance failure on r029 stop distances violated minimum requirements during extreme volatility",
+      cognitiveBiases: ["implementation bias"],
+      evolutionSummary: "Identified stop distance execution gap that needs systematic enforcement",
+      ruleUpdates: [], newRules: [],
+      systemPromptAdditions: "",
+      newSelfTasks: [], resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 150, rules);
+    expect(Array.isArray(result.newSelfTasks)).toBe(true);
+    expect(result.newSelfTasks.length).toBeGreaterThan(0);
+    expect(result.newSelfTasks.some((t: any) => t.category === "rule-gap")).toBe(true);
+  });
+
+  it("does not inject self-task when rule update accompanies the violation acknowledgement", () => {
+    const json = JSON.stringify({
+      whatWorked: "Good analysis",
+      whatFailed: "Compliance failure on r029 stop distances were too narrow",
+      cognitiveBiases: [],
+      evolutionSummary: "Updated stop rule to enforce wider distances",
+      ruleUpdates: [{ ruleId: "r029", type: "modify", before: "old text", after: "new text", reason: "enforce stop distance" }],
+      newRules: [], systemPromptAdditions: "",
+      newSelfTasks: [], resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 150, rules);
+    // No forced injection since a rule update is present
+    const forcedCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap" && /stop|r029/i.test(t.title ?? "")).length;
+    expect(forcedCount).toBe(0);
+  });
+
+  it("does not inject duplicate when axiom already created a rule-gap self-task", () => {
+    const json = JSON.stringify({
+      whatWorked: "Good analysis",
+      whatFailed: "Compliance violation on stop distances",
+      cognitiveBiases: [],
+      evolutionSummary: "Need to enforce stops at generation layer",
+      ruleUpdates: [], newRules: [], systemPromptAdditions: "",
+      newSelfTasks: [{ title: "Enforce stop validation", body: "Fix stop enforcement", category: "rule-gap", priority: "high" }],
+      resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 150, rules);
+    const ruleGapCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap").length;
+    expect(ruleGapCount).toBe(1); // only the one AXIOM already created, not a duplicate
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening } from "../src/validate";
+import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, detectAxiomRumination } from "../src/validate";
 import type { OracleAnalysis, JournalEntry } from "../src/types";
 
 // ── calculateTextSimilarity ─────────────────────────────────
@@ -811,5 +811,216 @@ describe("validateWeekendCryptoScreening", () => {
     const oracle = makeOracle({ analysis: "Bitcoin showing weakness." });
     const { covered, mentionedOnly, missing } = validateWeekendCryptoScreening(oracle, cryptoSnapshots);
     expect(covered.length + mentionedOnly.length + missing.length).toBe(cryptoSnapshots.length);
+  });
+});
+
+// ── filterNonCompliantSetups ─────────────────────────────────
+
+describe("filterNonCompliantSetups", () => {
+  function makeSnap(changePercent: number) {
+    return {
+      symbol: "NAS100", name: "NASDAQ 100", category: "indices" as const,
+      price: 25000, previousClose: 25000 / (1 + changePercent / 100),
+      change: 25000 * changePercent / 100, changePercent,
+      high: 25100, low: 24900, timestamp: new Date(),
+    };
+  }
+
+  function makeSetup(instrument: string, entry: number, stop: number, direction: "bullish" | "bearish" = "bullish") {
+    return {
+      instrument, type: "MSS" as const, direction,
+      description: "test", invalidation: "test",
+      entry, stop,
+      target: direction === "bullish" ? entry * 1.05 : entry * 0.95,
+      RR: 2, timeframe: "4H",
+    };
+  }
+
+  function makeOracle(snaps: ReturnType<typeof makeSnap>[], setups: ReturnType<typeof makeSetup>[]): OracleAnalysis {
+    return {
+      timestamp: new Date(), sessionId: "test", marketSnapshots: snaps,
+      analysis: "A".repeat(300), setups: setups as any,
+      bias: { overall: "mixed", notes: "volatile" }, keyLevels: [], confidence: 45,
+    };
+  }
+
+  it("removes setup with stop < 1.5% during extreme volatility (≥5% session move)", () => {
+    const oracle = makeOracle([makeSnap(5.5)], [makeSetup("NASDAQ 100", 25000, 24900)]); // 0.4% stop
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(0);
+    expect(removed).toHaveLength(1);
+    expect(removed[0].instrument).toBe("NASDAQ 100");
+  });
+
+  it("keeps setup with stop ≥ 1.5% during extreme volatility", () => {
+    const oracle = makeOracle([makeSnap(5.5)], [makeSetup("EUR/USD", 1.0, 0.984)]); // 1.6% stop — clearly compliant
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("removes setup with stop < 1.0% during moderate volatility (3–4.9% session move)", () => {
+    const oracle = makeOracle([makeSnap(3.5)], [makeSetup("GBP/USD", 1.34, 1.333)]); // ~0.52% stop
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(0);
+    expect(removed).toHaveLength(1);
+  });
+
+  it("keeps setup with stop ≥ 1.0% during moderate volatility", () => {
+    const oracle = makeOracle([makeSnap(3.5)], [makeSetup("GBP/USD", 1.34, 1.3265)]); // ~1.0% stop
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("keeps all setups during normal volatility (< 3% moves)", () => {
+    const oracle = makeOracle([makeSnap(1.5)], [makeSetup("EUR/USD", 1.17, 1.169)]); // 0.09% — would fail in extreme
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("keeps compliant and removes non-compliant in mixed setup list during extreme day", () => {
+    const oracle = makeOracle(
+      [makeSnap(5.2)],
+      [
+        makeSetup("NASDAQ 100", 25000, 24600), // 1.6% stop — compliant
+        makeSetup("EUR/USD", 1.17, 1.168),      // 0.17% stop — non-compliant
+      ]
+    );
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect((filtered.setups as any)[0].instrument).toBe("NASDAQ 100");
+    expect(removed[0].instrument).toBe("EUR/USD");
+  });
+
+  it("returns empty removed array when no setups present", () => {
+    const { removed } = filterNonCompliantSetups(
+      makeOracle([makeSnap(6.0)], [])
+    );
+    expect(removed).toHaveLength(0);
+  });
+
+  it("returns empty removed array when no snapshots present", () => {
+    const { removed } = filterNonCompliantSetups(
+      makeOracle([], [makeSetup("EUR/USD", 1.17, 1.169)])
+    );
+    expect(removed).toHaveLength(0);
+  });
+
+  it("does not mutate the original oracle object", () => {
+    const oracle = makeOracle([makeSnap(5.5)], [makeSetup("NASDAQ 100", 25000, 24900)]);
+    filterNonCompliantSetups(oracle);
+    expect(oracle.setups).toHaveLength(1); // original unchanged
+  });
+
+  it("uses absolute changePercent so negative moves also trigger filter", () => {
+    const oracle = makeOracle([makeSnap(-5.5)], [makeSetup("NASDAQ 100", 25000, 24900, "bearish")]); // bearish: stop above entry
+    // Bearish: stop 25100 vs entry 25000 = 0.4% — should be removed
+    const bearishOracle = makeOracle([makeSnap(-5.5)], [{
+      ...makeSetup("NASDAQ 100", 25000, 25100, "bearish"),
+      target: 24000,
+    } as any]);
+    const { removed } = filterNonCompliantSetups(bearishOracle);
+    expect(removed).toHaveLength(1);
+  });
+});
+
+// ── detectAxiomRumination ────────────────────────────────────
+
+describe("detectAxiomRumination", () => {
+  it("returns warning when whatFailed mentions compliance violation with no actions taken", () => {
+    const parsed = {
+      whatFailed: "Critical compliance failure on r029 — stop distances violated minimum requirements",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    };
+    const warning = detectAxiomRumination(parsed);
+    expect(warning).not.toBeNull();
+  });
+
+  it("returns warning when 'execution gap' language is present with no actions", () => {
+    const parsed = {
+      whatFailed: "This represents a systematic execution gap in stop distance compliance",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    };
+    expect(detectAxiomRumination(parsed)).not.toBeNull();
+  });
+
+  it("returns null when a rule update is present alongside violation text", () => {
+    const parsed = {
+      whatFailed: "Compliance failure on r029",
+      ruleUpdates: [{ ruleId: "r029", type: "modify", after: "new text", reason: "fix stops" }],
+      newRules: [], newSelfTasks: [],
+    };
+    expect(detectAxiomRumination(parsed)).toBeNull();
+  });
+
+  it("returns null when a new rule is present", () => {
+    const parsed = {
+      whatFailed: "Compliance violation on stop distances",
+      ruleUpdates: [],
+      newRules: [{ id: "r038", description: "enforce stops", category: "risk", weight: 9 }],
+      newSelfTasks: [],
+    };
+    expect(detectAxiomRumination(parsed)).toBeNull();
+  });
+
+  it("returns null when a self-task is present", () => {
+    const parsed = {
+      whatFailed: "Compliance violation on stop distances",
+      ruleUpdates: [], newRules: [],
+      newSelfTasks: [{ title: "Fix stop enforcement", body: "...", category: "rule-gap", priority: "high" }],
+    };
+    expect(detectAxiomRumination(parsed)).toBeNull();
+  });
+
+  it("returns null when whatFailed has no violation language", () => {
+    const parsed = {
+      whatFailed: "Analysis could use more cross-asset context in future sessions",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    };
+    expect(detectAxiomRumination(parsed)).toBeNull();
+  });
+
+  it("returns null when whatFailed is empty", () => {
+    const parsed = { whatFailed: "", ruleUpdates: [], newRules: [], newSelfTasks: [] };
+    expect(detectAxiomRumination(parsed)).toBeNull();
+  });
+});
+
+// ── validateAxiomOutput rumination integration ───────────────
+
+describe("validateAxiomOutput rumination detection", () => {
+  function makeAxiom(overrides: Record<string, any> = {}) {
+    return {
+      whatWorked: "Good analysis structure",
+      whatFailed: "Missed some correlations",
+      evolutionSummary: "Improved this session",
+      cognitiveBiases: [],
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+      ...overrides,
+    };
+  }
+
+  it("warns when axiom acknowledges compliance failure without any action", () => {
+    const result = validateAxiomOutput(
+      makeAxiom({
+        whatFailed: "Critical compliance failure on r029 stop distances violated minimum requirements",
+        ruleUpdates: [], newRules: [], newSelfTasks: [],
+      }),
+      5, []
+    );
+    expect(result.warnings.some((w) => w.includes("acknowledged failure without action"))).toBe(true);
+  });
+
+  it("does not warn when rule update accompanies the failure text", () => {
+    const result = validateAxiomOutput(
+      makeAxiom({
+        whatFailed: "Compliance failure on r029",
+        ruleUpdates: [{ ruleId: "r029", type: "modify", after: "fixed", reason: "stop enforcement" }],
+      }),
+      5, []
+    );
+    expect(result.warnings.some((w) => w.includes("acknowledged failure without action"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **r029 stop enforcement**: `filterNonCompliantSetups()` in `validate.ts` now hard-removes setups with stop distances below r029 minimums (≥1.5% for extreme volatility ≥5%, ≥1.0% for moderate ≥3%). Previously only a warning was emitted — ORACLE kept producing 0.2–0.5% stops on sessions #148/#149 with no consequence.
- **AXIOM rumination detection**: `detectAxiomRumination()` detects when AXIOM's `whatFailed` contains compliance/violation language but all action arrays (`ruleUpdates`, `newRules`, `newSelfTasks`) are empty. `validateAxiomOutput()` surfaces it as a warning; `parseAxiomResponse()` injects a forced `rule-gap` self-task automatically.
- **agent.ts**: calls `filterNonCompliantSetups()` after oracle validation and logs each removed setup with instrument name and reason.

## Root cause
Sessions #148 and #149 both had AXIOM explicitly identify r029 stop violations two sessions in a row — yet produced no rule updates or self-tasks. The system had no mechanism to block bad setups or force action on acknowledged failures.

## Test plan
- [ ] 424 tests passing (`npm test`)
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] `filterNonCompliantSetups` removes 0.2–0.5% stops during extreme volatility sessions
- [ ] Forced self-task injected when AXIOM acknowledges violation without action
- [ ] Compliant setups (≥1.5% stop on extreme day) pass through unchanged