### PR TITLE
fix(oracle): inject r029 stop distance enforcement into ORACLE-SETUPS prompt

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -268,6 +268,8 @@ START WITH THIS TEMPLATE (fill in every slot):
 ${weekendTemplate}
 \n` : "";
 
+  const r029Note = buildR029StopNote(snapshots);
+
   const setupsUserMessage = `You are NEXUS ORACLE's setup construction engine. You have just completed market analysis.
 ${weekendSetupNote}
 
@@ -293,7 +295,7 @@ RULES:
 - Weekend crypto sessions: at least 2 setups from available crypto instruments regardless of confidence
 - Every setup MUST have: entry, stop, target, RR, timeframe
 - ENTRY: nearest support/resistance, session high/low, or key level
-- STOP: beyond the next structural level, or 1x ATR from entry
+- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}
 - TARGET: next liquidity level, psychological number, or swing point
 - RR must be > 1.3 \u2014 do not include setups with risk exceeding reward
 - Include instrument, type, direction, description, and invalidation
@@ -573,6 +575,25 @@ export function warnPoorRiskReward(setups: any[]): void {
       console.warn(`  ⚠ Setup ${s.instrument ?? "unknown"} has poor risk/reward (RR=${s.RR.toFixed(2)}) — minimum 1.3 required`);
     }
   }
+}
+
+// ── r029 stop distance enforcement ────────────────────────
+// Returns a prompt block telling ORACLE the minimum stop distance required
+// for this session based on live market volatility. Empty string = no constraint.
+export function buildR029StopNote(snapshots: MarketSnapshot[]): string {
+  if (!snapshots.length) return "";
+  const maxMove = Math.max(...snapshots.map(s => Math.abs(s.changePercent ?? 0)));
+  if (maxMove >= 5) {
+    return `\nMANDATORY STOP REQUIREMENT (r029 — extreme volatility detected: max session move ${maxMove.toFixed(1)}%):
+Every stop MUST be at least 1.5% from entry. Verify before finalising: |entry - stop| / entry ≥ 0.015.
+Do NOT include any setup where the stop is closer than 1.5% from entry.\n`;
+  }
+  if (maxMove >= 3) {
+    return `\nMANDATORY STOP REQUIREMENT (r029 — moderate volatility detected: max session move ${maxMove.toFixed(1)}%):
+Every stop MUST be at least 1.0% from entry. Verify before finalising: |entry - stop| / entry ≥ 0.010.
+Do NOT include any setup where the stop is closer than 1.0% from entry.\n`;
+  }
+  return "";
 }
 
 // ── Formatters ─────────────────────────────────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,4 +1,59 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { buildR029StopNote } from "../src/oracle";
+import type { MarketSnapshot } from "../src/types";
+
+function makeSnap(changePercent: number): MarketSnapshot {
+  return { symbol: "EUR=X", name: "EUR/USD", category: "forex", price: 1.10, previousClose: 1.0, change: 0, changePercent, high: 1.11, low: 1.09, timestamp: new Date() };
+}
+
+// ── buildR029StopNote ─────────────────────────────────────
+
+describe("buildR029StopNote", () => {
+  it("returns empty string when no volatility (all moves < 3%)", () => {
+    const snaps = [makeSnap(1.5), makeSnap(-2.0), makeSnap(0.5)];
+    expect(buildR029StopNote(snaps)).toBe("");
+  });
+
+  it("returns extreme volatility note when any move >= 5%", () => {
+    const snaps = [makeSnap(1.0), makeSnap(5.2), makeSnap(-2.0)];
+    const note = buildR029StopNote(snaps);
+    expect(note).toContain("1.5%");
+    expect(note).toContain("extreme volatility");
+    expect(note).toContain("5.2%");
+  });
+
+  it("returns moderate volatility note when max move >= 3% but < 5%", () => {
+    const snaps = [makeSnap(1.0), makeSnap(3.8), makeSnap(-1.0)];
+    const note = buildR029StopNote(snaps);
+    expect(note).toContain("1.0%");
+    expect(note).toContain("moderate volatility");
+    expect(note).not.toContain("1.5%");
+  });
+
+  it("uses absolute value of negative moves", () => {
+    const snaps = [makeSnap(-6.0), makeSnap(1.0)];
+    const note = buildR029StopNote(snaps);
+    expect(note).toContain("1.5%");
+    expect(note).toContain("extreme volatility");
+  });
+
+  it("returns empty string for empty snapshots array", () => {
+    expect(buildR029StopNote([])).toBe("");
+  });
+
+  it("includes r029 rule reference", () => {
+    const snaps = [makeSnap(5.0)];
+    const note = buildR029StopNote(snaps);
+    expect(note).toContain("r029");
+  });
+
+  it("includes a stop calculation example", () => {
+    const snaps = [makeSnap(5.0)];
+    const note = buildR029StopNote(snaps);
+    // Should tell ORACLE HOW to verify: |entry - stop| / entry
+    expect(note.toLowerCase()).toMatch(/entry.*stop|stop.*entry/);
+  });
+});
 
 // ── Export presence tests ──────────────────────────────────
 


### PR DESCRIPTION
## Problem

ORACLE was generating stop losses based purely on structural levels, with no awareness of the volatility-adjusted minimum distances required by r029. The rule text lived in the system prompt, but ORACLE never computed it — so during extreme volatility sessions (≥5% moves), it consistently produced 0.2–0.5% stops.

Result: `filterNonCompliantSetups()` silently removed them, leaving 0–1 setups. AXIOM then noticed the gap, wrote the same system prompt addition every session ("implement mandatory stop distance verification"), and the cycle repeated with no change.

Sessions #148–#150 all show identical AXIOM reflections about r029 despite the post-hoc filter already being in place.

## Fix

Add `buildR029StopNote(snapshots)` which computes the max `|changePercent|` from live market data and injects a **MANDATORY STOP REQUIREMENT** block directly into the `setupsUserMessage` RULES section:

- Extreme volatility (≥5%): stops must be ≥1.5% from entry  
- Moderate volatility (≥3%): stops must be ≥1.0% from entry  
- Normal sessions: no additional constraint (empty string)

The block includes an explicit verification formula (`|entry - stop| / entry ≥ 0.015`) so ORACLE can self-check before finalising each setup.

## Tests

7 new unit tests in `tests/oracle.test.ts` covering all threshold branches, absolute value of negative moves, empty snapshots, and formula presence.

## Expected outcome

ORACLE generates compliant stops at construction time → `filterNonCompliantSetups()` has nothing to remove → AXIOM stops ruminating about r029 → evolution energy goes elsewhere.

## Review checklist
- [ ] `buildR029StopNote` returns empty string when no volatility
- [ ] Extreme (≥5%) branch injects 1.5% requirement
- [ ] Moderate (≥3%) branch injects 1.0% requirement
- [ ] Injected into `setupsUserMessage` RULES section inline
- [ ] TypeScript clean, all 431 tests pass