### PR TITLE
fix(oracle,validate): inject mandatory setup count into ORACLE prompt + expand rumination detection

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -269,6 +269,7 @@ ${weekendTemplate}
 \n` : "";
 
   const r029Note = buildR029StopNote(snapshots);
+  const minSetupNote = buildMinSetupNote(parsed.confidence ?? 50);
 
   const setupsUserMessage = `You are NEXUS ORACLE's setup construction engine. You have just completed market analysis.
 ${weekendSetupNote}
@@ -291,7 +292,7 @@ RULES:
 - You MUST systematically evaluate EVERY instrument in the price data for potential setups
 - For each instrument, either include a setup OR briefly note why none exists (no structural level nearby, no alignment with theme)
 - When a clear macro theme is present (USD strength, risk-off, forced liquidation, correlation breakdown), you MUST screen all asset classes: forex majors, indices, crypto, metals, energy
-- Minimum setups: at least 3 when confidence > 50%, at least 4 when confidence > 60%
+- Minimum setups: at least 3 when confidence > 50%, at least 4 when confidence > 60%${minSetupNote}
 - Weekend crypto sessions: at least 2 setups from available crypto instruments regardless of confidence
 - Every setup MUST have: entry, stop, target, RR, timeframe
 - ENTRY: nearest support/resistance, session high/low, or key level
@@ -594,6 +595,15 @@ Every stop MUST be at least 1.0% from entry. Verify before finalising: |entry - 
 Do NOT include any setup where the stop is closer than 1.0% from entry.\n`;
   }
   return "";
+}
+
+// ── Minimum setup count enforcement ───────────────────────
+// Returns a prompt block telling ORACLE how many setups are MANDATORY
+// based on its reported confidence. Empty string when confidence < 50.
+export function buildMinSetupNote(confidence: number): string {
+  if (confidence < 50) return "";
+  const minSetups = confidence >= 60 ? 4 : 3;
+  return `\nMANDATORY SETUP COUNT (your confidence is ${confidence}%): You MUST provide at least ${minSetups} setups. Returning fewer is a rule violation (r034). Systematically screen ALL instruments — forex majors, indices, crypto, commodities — before concluding no setup exists.\n`;
 }
 
 // ── Formatters ─────────────────────────────────────────────

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -440,7 +440,7 @@ export function filterNonCompliantSetups(oracle: OracleAnalysis): {
 const VIOLATION_KEYWORDS = [
   "compliance failure", "compliance violation", "execution gap",
   "systematic failure", "failed to implement", "failed to comply",
-  "failed to apply", "violation", "non-compliant",
+  "failed to apply", "failed to execute", "violation", "non-compliant",
 ];
 
 export function detectAxiomRumination(parsed: {

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -939,3 +939,43 @@ describe("runOracleAnalysis assumptions field", () => {
     expect(result.assumptions!.length).toBe(0);
   });
 });
+
+// ── buildMinSetupNote ─────────────────────────────────────
+
+import { buildMinSetupNote } from "../src/oracle";
+
+describe("buildMinSetupNote", () => {
+  it("returns empty string when confidence < 50", () => {
+    expect(buildMinSetupNote(45)).toBe("");
+  });
+
+  it("requires at least 3 setups when confidence 50-59", () => {
+    const note = buildMinSetupNote(55);
+    expect(note).toContain("3");
+    expect(note.toLowerCase()).toContain("mandatory");
+  });
+
+  it("requires at least 4 setups when confidence 60-69", () => {
+    const note = buildMinSetupNote(65);
+    expect(note).toContain("4");
+    expect(note.toLowerCase()).toContain("mandatory");
+  });
+
+  it("requires at least 4 setups when confidence >= 70", () => {
+    const note = buildMinSetupNote(80);
+    expect(note).toContain("4");
+  });
+
+  it("includes confidence value in the note", () => {
+    const note = buildMinSetupNote(72);
+    expect(note).toContain("72");
+  });
+
+  it("returns empty string at exactly 49", () => {
+    expect(buildMinSetupNote(49)).toBe("");
+  });
+
+  it("triggers at exactly 50", () => {
+    expect(buildMinSetupNote(50)).not.toBe("");
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1024,3 +1024,25 @@ describe("validateAxiomOutput rumination detection", () => {
     expect(result.warnings.some((w) => w.includes("acknowledged failure without action"))).toBe(false);
   });
 });
+
+// ── detectAxiomRumination — "failed to execute" keyword ──────
+
+describe("detectAxiomRumination — failed to execute keyword", () => {
+  it("triggers when whatFailed contains 'failed to execute'", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "I failed to execute comprehensive screening despite having the analytical framework for it.",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("acknowledged failure without action");
+  });
+
+  it("does not trigger 'failed to execute' when a rule update accompanies it", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "I failed to execute systematic screening per r034.",
+      ruleUpdates: [{ ruleId: "r034", type: "modify", before: "old", after: "new", reason: "enforce" }],
+      newRules: [], newSelfTasks: [],
+    });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Session #151 showed the same enforcement-complaint pattern, now about setup count (r034) instead of stop distances (r029). ORACLE generated 2 setups with 61% confidence despite the rule requiring ≥4. AXIOM reflected: *"I need better enforcement mechanisms"* — but took no action, so `detectAxiomRumination` didn't fire because it used **"failed to execute"** rather than any keyword in our list.

## Fixes

### 1. `buildMinSetupNote(confidence)` in `oracle.ts`
Injects a `MANDATORY SETUP COUNT` block directly into the `setupsUserMessage` RULES section, computed from ORACLE's actual confidence score:
- confidence ≥ 60 → at least 4 setups required
- confidence ≥ 50 → at least 3 setups required
- confidence < 50 → no constraint (empty string)

Same pattern as the r029 fix in #48 — explicit computed constraint beats passive rule text.

### 2. `"failed to execute"` added to `VIOLATION_KEYWORDS` in `validate.ts`
AXIOM's exact phrase in #151 was *"failed to execute comprehensive screening"* — not in our keyword list, so rumination detection was silently bypassed.

## Tests
- 7 new tests for `buildMinSetupNote` (all threshold branches, edge cases at 49/50)
- 2 new tests for `detectAxiomRumination` with "failed to execute" keyword

## Review checklist
- [ ] `buildMinSetupNote(65)` returns note containing "4" and "mandatory"
- [ ] `buildMinSetupNote(45)` returns empty string
- [ ] `detectAxiomRumination` fires on "failed to execute" with no actions
- [ ] TypeScript clean, all 440 tests pass