### PR TITLE
fix(oracle): force systematic instrument screening via weekday template when confidence ≥50

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -271,8 +271,23 @@ ${weekendTemplate}
   const r029Note = buildR029StopNote(snapshots);
   const minSetupNote = buildMinSetupNote(parsed.confidence ?? 50);
 
+  const rawConf = parsed.confidence ?? 50;
+  const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
+  const weekdayScreeningNote = weekdayTemplate
+    ? `\nSYSTEMATIC SCREENING REQUIRED (your confidence is ${rawConf}%):
+You MUST fill in EVERY slot in the JSON template below. Do NOT add or remove slots.
+For each instrument:
+  - If a valid structural level exists aligned with your bias → fill in entry, stop, target, RR, timeframe, set direction to "bullish" or "bearish"
+  - If no valid setup exists → leave entry/stop/target/RR/timeframe as null, set direction to "neutral", explain briefly in description
+All ${snapshots.length} instruments must be accounted for. Returning fewer slots is a rule violation (r034).
+
+START WITH THIS TEMPLATE (fill in every slot):
+${weekdayTemplate}
+\n`
+    : "";
+
   const setupsUserMessage = `You are NEXUS ORACLE's setup construction engine. You have just completed market analysis.
-${weekendSetupNote}
+${weekendSetupNote}${weekdayScreeningNote}
 
 YOUR ANALYSIS:
 ${parsed.analysis ?? ""}
@@ -595,6 +610,28 @@ Every stop MUST be at least 1.0% from entry. Verify before finalising: |entry - 
 Do NOT include any setup where the stop is closer than 1.0% from entry.\n`;
   }
   return "";
+}
+
+// ── Weekday instrument screening template ─────────────────
+// When confidence >= 50 on weekday sessions, returns a pre-filled JSON template
+// (same pattern as the weekend template) forcing ORACLE to evaluate every
+// instrument instead of cherry-picking the most dramatic one.
+// Empty string when confidence < 50 or no snapshots.
+export function buildWeekdayScreeningTemplate(snapshots: MarketSnapshot[], confidence: number): string {
+  if (confidence < 50 || !snapshots.length) return "";
+  const slots = snapshots.map(s => ({
+    instrument:   s.name,
+    type:         "Other",
+    direction:    "neutral",
+    description:  "",
+    invalidation: "",
+    entry:        null,
+    stop:         null,
+    target:       null,
+    RR:           null,
+    timeframe:    null,
+  }));
+  return JSON.stringify(slots, null, 2);
 }
 
 // ── Minimum setup count enforcement ───────────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate } from "../src/oracle";
 import type { MarketSnapshot } from "../src/types";
 
 function makeSnap(changePercent: number): MarketSnapshot {
@@ -977,5 +977,56 @@ describe("buildMinSetupNote", () => {
 
   it("triggers at exactly 50", () => {
     expect(buildMinSetupNote(50)).not.toBe("");
+  });
+});
+
+// ── buildWeekdayScreeningTemplate ────────────────────────
+
+describe("buildWeekdayScreeningTemplate", () => {
+  const snaps: MarketSnapshot[] = [
+    { symbol: "EURUSD=X", name: "EUR/USD", category: "forex", price: 1.10, previousClose: 1.08, change: 0.02, changePercent: 1.92, high: 1.11, low: 1.09, timestamp: new Date() },
+    { symbol: "GC=F",     name: "Gold",    category: "commodities", price: 3300, previousClose: 3290, change: 10, changePercent: 0.30, high: 3310, low: 3285, timestamp: new Date() },
+    { symbol: "BTC-USD",  name: "Bitcoin", category: "crypto", price: 82000, previousClose: 80000, change: 2000, changePercent: 2.5, high: 82500, low: 79000, timestamp: new Date() },
+  ];
+
+  it("returns empty string when confidence < 50", () => {
+    expect(buildWeekdayScreeningTemplate(snaps, 45)).toBe("");
+  });
+
+  it("returns empty string at exactly 49", () => {
+    expect(buildWeekdayScreeningTemplate(snaps, 49)).toBe("");
+  });
+
+  it("returns a template string at confidence 50", () => {
+    expect(buildWeekdayScreeningTemplate(snaps, 50)).not.toBe("");
+  });
+
+  it("template contains all instrument names", () => {
+    const tmpl = buildWeekdayScreeningTemplate(snaps, 60);
+    expect(tmpl).toContain("EUR/USD");
+    expect(tmpl).toContain("Gold");
+    expect(tmpl).toContain("Bitcoin");
+  });
+
+  it("template is valid JSON with a slot per instrument", () => {
+    const tmpl = buildWeekdayScreeningTemplate(snaps, 60);
+    const parsed = JSON.parse(tmpl);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(snaps.length);
+  });
+
+  it("each slot has null entry/stop/target and neutral direction", () => {
+    const tmpl = buildWeekdayScreeningTemplate(snaps, 60);
+    const parsed = JSON.parse(tmpl);
+    for (const slot of parsed) {
+      expect(slot.entry).toBeNull();
+      expect(slot.stop).toBeNull();
+      expect(slot.target).toBeNull();
+      expect(slot.direction).toBe("neutral");
+    }
+  });
+
+  it("returns empty string for empty snapshots regardless of confidence", () => {
+    expect(buildWeekdayScreeningTemplate([], 80)).toBe("");
   });
 });


### PR DESCRIPTION
## Problem

Sessions #151 and #152 both had 67% confidence (pre-calibration) but ORACLE returned 1 setup each time. The mandatory count note injected in #49 didn't help — ORACLE won't manufacture setups to hit a number. It needs structural forcing.

The weekend sessions don't have this problem because `buildWeekendInstrumentTemplate` generates a pre-filled JSON slot for every crypto instrument, requiring ORACLE to address each one explicitly. That structural constraint is what makes weekend screening work.

## Fix

Extended the same pattern to weekday sessions via `buildWeekdayScreeningTemplate(snapshots, confidence)`:

- Returns a pre-filled JSON template (one slot per instrument, all nulls, direction = "neutral") when confidence ≥ 50
- Empty string when confidence < 50 — normal sessions are unaffected
- Injects a `weekdayScreeningNote` block into `setupsUserMessage` with the same instruction style as `weekendSetupNote`
- ORACLE must fill every slot: valid setup → bullish/bearish + entry/stop/target/RR/TF; no setup → direction neutral + reason in description
- Existing null-field validation drops neutral entries, consistent with current weekday flow

## Tests

7 new unit tests for `buildWeekdayScreeningTemplate`:
- Returns empty string below confidence 50 (including exactly 49)
- Returns template at exactly 50
- Template contains all instrument names
- Template is valid JSON with one slot per instrument
- Each slot has null entry/stop/target and neutral direction
- Returns empty string for empty snapshots

## Expected outcome

ORACLE must walk through all 45 weekday instruments and justify skipping each one, rather than latching on to the most dramatic move and returning early.

## Review checklist
- [ ] Only fires on weekday sessions when confidence ≥ 50
- [ ] Template has one slot per snapshot
- [ ] Mutually exclusive with weekendSetupNote (isWeekend guard)
- [ ] TypeScript clean, all 447 tests pass