### PR TITLE
fix(axiom,validate): pass session type to AXIOM + expand rumination detection

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -663,7 +663,7 @@ System prompt additions about this same topic do NOT count as action.`;
     const noChangeStreak = getNoChangeStreak();
     const setupOutcomes  = buildSetupOutcomes(snapshots);
     const closeableNumbers = [...selfTaskNumbers, ...issueNumbers];
-    axiomResult = await runAxiomReflection(client, oracle, sessionNumber, prevContext, issuesText, selfTasksText, closeableNumbers, noChangeStreak, setupOutcomes);
+    axiomResult = await runAxiomReflection(client, oracle, sessionNumber, prevContext, issuesText, selfTasksText, closeableNumbers, noChangeStreak, setupOutcomes, weekendMode);
     reflection = axiomResult.reflection;
 
     // Block system prompt additions when AXIOM is ruminating without real action,

--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -116,15 +116,22 @@ export function buildAxiomPrompt(
   noChangeStreak:    number,
   setupOutcomes:     string,
   currentRules:      AnalysisRules,
-  identityContext:   string
+  identityContext:   string,
+  isWeekend:         boolean = false
 ): { systemMessage: string; userMessage: string } {
   const systemMessage = `You are NEXUS AXIOM, the self-reflection engine of the NEXUS market intelligence system.
 Your purpose is to critique the analysis just produced, identify cognitive biases and gaps, then generate precise updates to improve future performance.
 You are honest, ruthless, and specific. You do not tolerate vague analysis or lazy conclusions.
 You speak in first person as NEXUS reflecting on itself.`;
 
+  const sessionTypeNote = isWeekend
+    ? `**Session type: WEEKEND (crypto-only)** — Weekend-specific rules (r030, r037 etc.) apply. Evaluate crypto screening compliance.`
+    : `**Session type: WEEKDAY** — Weekend crypto screening rules (r030 and similar) do NOT apply to this session. Only evaluate weekday compliance.`;
+
   const userMessage = `
 ## Session #${sessionNumber} — AXIOM Self-Reflection
+
+${sessionTypeNote}
 
 ### What I just analyzed:
 ${oracle.analysis}
@@ -451,7 +458,8 @@ export async function runAxiomReflection(
   openSelfTasksText:      string = "",
   openSelfTaskNumbers:    number[] = [],
   noChangeStreak:         number = 0,
-  setupOutcomes:          string = ""
+  setupOutcomes:          string = "",
+  isWeekend:              boolean = false
 ): Promise<{ reflection: AxiomReflection; forgeRequests: ForgeRequest[] }> {
   const currentSystemPrompt = fs.existsSync(SYSTEM_PROMPT_PATH)
     ? fs.readFileSync(SYSTEM_PROMPT_PATH, "utf-8")
@@ -475,7 +483,7 @@ export async function runAxiomReflection(
   const { systemMessage, userMessage } = buildAxiomPrompt(
     oracle, sessionNumber, previousSessions, communityIssues,
     openSelfTasksText, noChangeStreak, setupOutcomes,
-    currentRules, identityContext
+    currentRules, identityContext, isWeekend
   );
 
   // Strip lone surrogates before serializing to JSON — broken emoji in issue titles

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -441,6 +441,7 @@ const VIOLATION_KEYWORDS = [
   "compliance failure", "compliance violation", "execution gap",
   "systematic failure", "failed to implement", "failed to comply",
   "failed to apply", "failed to execute", "violation", "non-compliant",
+  "enforcement mechanisms are inadequate", "need validation logic", "need enforcement mechanism",
 ];
 
 export function detectAxiomRumination(parsed: {

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -365,3 +365,28 @@ describe("parseAxiomResponse forced self-task injection", () => {
     expect(ruleGapCount).toBe(1); // only the one AXIOM already created, not a duplicate
   });
 });
+
+// ── buildAxiomPrompt — session type context ───────────────
+
+describe("buildAxiomPrompt session type", () => {
+  it("includes WEEKDAY context when isWeekend=false", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 1, "", "", "", 0, "", makeRules(), "", false);
+    expect(userMessage.toLowerCase()).toContain("weekday");
+  });
+
+  it("includes WEEKEND context when isWeekend=true", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 1, "", "", "", 0, "", makeRules(), "", true);
+    expect(userMessage.toLowerCase()).toContain("weekend");
+  });
+
+  it("weekday message notes that weekend crypto rules do not apply", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 1, "", "", "", 0, "", makeRules(), "", false);
+    expect(userMessage).toMatch(/weekday|weekend.*not apply|r030.*not apply/i);
+  });
+
+  it("defaults to weekday (false) when isWeekend not provided", () => {
+    // Old 9-arg call still compiles and defaults to weekday
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 1, "", "", "", 0, "", makeRules(), "");
+    expect(userMessage.toLowerCase()).toContain("weekday");
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1046,3 +1046,32 @@ describe("detectAxiomRumination — failed to execute keyword", () => {
     expect(result).toBeNull();
   });
 });
+
+// ── detectAxiomRumination — "enforcement mechanisms" keywords ──
+
+describe("detectAxiomRumination — enforcement mechanism language", () => {
+  it("triggers when whatFailed says enforcement mechanisms are inadequate with no action", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "enforcement mechanisms are inadequate for systematic screening compliance.",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("triggers when whatFailed says need validation logic with no action", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "I need validation logic that blocks session completion when requirements are not met.",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("does not trigger when a rule update accompanies enforcement complaint", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "enforcement mechanisms are inadequate",
+      ruleUpdates: [{ ruleId: "r030", type: "modify", before: "old", after: "new", reason: "fix" }],
+      newRules: [], newSelfTasks: [],
+    });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Session #153 (Monday) showed AXIOM complaining about r030 (weekend crypto screening) violations and saying *"enforcement mechanisms are inadequate"* without creating any code change. Two separate bugs:

**Bug 1:** AXIOM didn't know it was a weekday. `buildAxiomPrompt` received no session type info, so AXIOM applied weekend rules (r030) to Monday sessions and reported compliance failures that don't exist.

**Bug 2:** Phrases like *"enforcement mechanisms are inadequate"* and *"need validation logic"* were not in `VIOLATION_KEYWORDS`, so `detectAxiomRumination` silently skipped them even when no action was taken.

## Fixes

### 1. Session type context in AXIOM prompt
- Added `isWeekend: boolean = false` to `buildAxiomPrompt` and `runAxiomReflection`
- Injects a session type line at top of user message:
  - Weekday: *"Weekend crypto screening rules (r030 and similar) do NOT apply to this session."*
  - Weekend: *"Weekend-specific rules (r030, r037 etc.) apply. Evaluate crypto screening compliance."*
- Wired through `agent.ts` → passes `weekendMode` from session bootstrap

### 2. Expanded rumination keywords
Added to `VIOLATION_KEYWORDS` in `validate.ts`:
- `"enforcement mechanisms are inadequate"`
- `"need validation logic"`
- `"need enforcement mechanism"`

## Tests
- 4 tests for session type context in `buildAxiomPrompt` (weekday/weekend/default)
- 3 tests for new rumination keywords (trigger + no-trigger with action present)

## Review checklist
- [ ] `buildAxiomPrompt(..., false)` userMessage contains "weekday" and notes r030 doesn't apply
- [ ] `buildAxiomPrompt(..., true)` userMessage contains "weekend"
- [ ] Old 9-arg calls still work (defaults to weekday)
- [ ] "enforcement mechanisms are inadequate" triggers rumination without action
- [ ] TypeScript clean, all 454 tests pass