### PR TITLE
fix(self-tasks): mandate action on open tasks, tighten stagnation alert

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -201,9 +201,7 @@ ${setupOutcomes ? "### Setup outcome tracking:\n" + setupOutcomes : ""}
 
 ${noChangeStreak >= 3 ? `### STAGNATION ALERT
 You have not modified any rules in ${noChangeStreak} consecutive sessions.
-Your self-critiques are repeating without action. This session, you MUST propose
-at least ONE concrete change — a rule weight adjustment, wording refinement,
-new rule, system prompt addition, or code change. Reflection without action is not evolution.
+Your self-critiques are repeating without action.${openSelfTasksText ? ` You have open self-tasks listed above that you have not acted on — generating codeChanges or resolvedSelfTasks for those tasks IS the required concrete action this session. Do not add system prompt text. Do not open new tasks. Act on the existing ones.` : ` This session, you MUST propose at least ONE concrete change — a rule weight adjustment, wording refinement, new rule, or code change.`} Reflection without action is not evolution.
 ` : ""}### Codebase context (so you can write precise codeChanges):
 ${buildCodebaseContext(openSelfTasksText)}
 

--- a/src/self-tasks.ts
+++ b/src/self-tasks.ts
@@ -212,7 +212,7 @@ export function formatSelfTasksForPrompt(tasks: OpenSelfTask[]): string {
 
   const lines = [
     "=== MY OPEN SELF-TASKS ===",
-    `I filed ${tasks.length} task(s) for myself in previous sessions. I should address them if I have enough information this session.\n`,
+    `I filed ${tasks.length} task(s) for myself in previous sessions. For EACH task below, I MUST output either (a) a codeChange entry targeting it, or (b) a resolvedSelfTask entry explaining how it was addressed. Leaving any task without a codeChange or resolvedSelfTask response is a compliance violation.\n`,
   ];
 
   for (const t of tasks) {

--- a/tests/self-tasks.test.ts
+++ b/tests/self-tasks.test.ts
@@ -29,6 +29,17 @@ describe("formatSelfTasksForPrompt", () => {
     expect(result).not.toContain("Filed by NEXUS");
   });
 
+  it("uses mandatory action language, not optional", () => {
+    const tasks: OpenSelfTask[] = [{
+      number: 1, title: "Task A", body: "Body A",
+      category: "rule-gap", sessionOpened: 1, url: "https://example.com/1",
+    }];
+    const result = formatSelfTasksForPrompt(tasks);
+    expect(result).toContain("MUST output either");
+    expect(result).toContain("compliance violation");
+    expect(result).not.toContain("I should address them if I have enough information");
+  });
+
   it("formats multiple tasks", () => {
     const tasks: OpenSelfTask[] = [
       {


### PR DESCRIPTION
## Summary
- `formatSelfTasksForPrompt`: replaces weak "should address if enough info" with an explicit mandate — each open task requires a `codeChange` or `resolvedSelfTask` entry; leaving one unresponded is flagged as a compliance violation
- `buildAxiomPrompt`: stagnation alert (streak ≥ 3) now explicitly directs AXIOM to act on the specific open self-tasks listed above, rather than drifting to generic system prompt additions
- Closes self-task #53 (volatility stop validation already handled by `filterNonCompliantSetups()` in PR #46)

## Root cause
Sessions #155–157 all had open self-tasks (#52, #53) visible in the AXIOM prompt but AXIOM treated them as optional ("I should address them if I have enough information"). Combined with a stagnation alert that only said "make ONE change", AXIOM kept writing system prompt text instead of generating `codeChanges`.

## Test plan
- [ ] 36/36 tests pass (`vitest run tests/self-tasks.test.ts tests/axiom.test.ts`)
- [ ] New test: `formatSelfTasksForPrompt` output contains "MUST output either" and "compliance violation"
- [ ] `tsc --noEmit` clean