### PR TITLE
fix(validate,axiom): r034 zero-setup check + validate.ts in AXIOM context

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -28,7 +28,7 @@ import type {
 // AXIOM can write precise codeChanges instructions.
 
 const MAX_FILE_INJECT_CHARS = 3000; // per file
-const ALWAYS_INJECT = ["journal.ts", "agent.ts"]; // always show these to AXIOM
+const ALWAYS_INJECT = ["journal.ts", "agent.ts", "validate.ts"]; // always show these to AXIOM
 
 function buildCodebaseContext(openSelfTasksText: string): string {
   const srcDir      = path.join(process.cwd(), "src");

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -315,6 +315,32 @@ export function validateOracleOutput(
     }
   }
 
+  // r034: zero setups with directional/mixed confidence requires level rejection documentation.
+  // When confidence ≥50% and bias is not neutral, producing zero setups is only acceptable
+  // if the analysis explicitly documents which levels were evaluated and why each was rejected.
+  // Without that documentation, zero setups = undetectable screening failure.
+  if (
+    typeof oracle.confidence === "number" &&
+    oracle.confidence >= 50 &&
+    oracle.bias?.overall !== "neutral" &&
+    (oracle.setups?.length ?? 0) === 0
+  ) {
+    const rejectionMarkers = [
+      "poor rr", "poor r:r", "conflicting timeframe", "insufficient confluence",
+      "no viable", "rejected", "evaluated", "screened",
+      "level evaluated", "structural level", "key level identified",
+    ];
+    const analysisLower = (oracle.analysis ?? "").toLowerCase();
+    const hasRejectionDoc = rejectionMarkers.some(p => analysisLower.includes(p));
+    if (!hasRejectionDoc) {
+      warnings.push(
+        `r034: ${oracle.confidence}% confidence with ${oracle.bias?.overall} bias produced zero setups ` +
+        `but analysis contains no structural level evaluation or rejection reasoning — ` +
+        `document which levels were screened and why each was rejected (poor RR, conflicting timeframe, insufficient confluence)`
+      );
+    }
+  }
+
   // "Other" type overuse — ICT types should be preferred
   if (oracle.setups && oracle.setups.length > 0) {
     const otherCount = oracle.setups.filter(s => s.type === "Other").length;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -372,6 +372,75 @@ describe("validateOracleOutput", () => {
   });
 });
 
+// ── r034: zero-setup screening documentation check ──────────────
+
+describe("validateOracleOutput r034 zero-setup check", () => {
+  function makeZeroSetupOracle(overrides: Partial<OracleAnalysis> = {}): OracleAnalysis {
+    return {
+      sessionId: "test",
+      timestamp: new Date().toISOString(),
+      analysis: "Major coordinated rally across all asset classes. USD weakness confirmed across multiple pairs.",
+      bias: { overall: "bullish", notes: "Coordinated risk-on" },
+      confidence: 50,
+      setups: [],
+      keyLevels: [],
+      marketSnapshots: [],
+      assumptions: [],
+      ...overrides,
+    };
+  }
+
+  it("warns when confidence >= 50 with bullish bias and zero setups and no rejection doc", () => {
+    const result = validateOracleOutput(makeZeroSetupOracle(), []);
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(true);
+  });
+
+  it("warns when confidence >= 50 with mixed bias and zero setups and no rejection doc", () => {
+    const result = validateOracleOutput(
+      makeZeroSetupOracle({ bias: { overall: "mixed", notes: "divergence" } }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(true);
+  });
+
+  it("does not warn when analysis documents rejection reasoning (poor RR)", () => {
+    const result = validateOracleOutput(
+      makeZeroSetupOracle({ analysis: "Evaluated EUR/USD at 1.18 resistance — poor RR at this level given current volatility." }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(false);
+  });
+
+  it("does not warn when analysis documents rejection reasoning (conflicting timeframe)", () => {
+    const result = validateOracleOutput(
+      makeZeroSetupOracle({ analysis: "Screened all forex majors — conflicting timeframe signals on 1H vs 4H prevented setup identification." }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(false);
+  });
+
+  it("does not warn when confidence < 50 with zero setups", () => {
+    const result = validateOracleOutput(makeZeroSetupOracle({ confidence: 49 }), []);
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(false);
+  });
+
+  it("does not warn when bias is neutral with zero setups", () => {
+    const result = validateOracleOutput(
+      makeZeroSetupOracle({ confidence: 55, bias: { overall: "neutral", notes: "" } }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(false);
+  });
+
+  it("does not warn when zero setups but setups exist (sanity)", () => {
+    const result = validateOracleOutput(
+      makeZeroSetupOracle({ setups: [{ instrument: "EUR/USD", type: "FVG", direction: "bullish", entry: 1.18, stop: 1.17, target: 1.20, RR: 2, timeframe: "1H" }] }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(false);
+  });
+});
+
 // ── extractConfidenceFromText ────────────────────────────────
 
 describe("extractConfidenceFromText", () => {


### PR DESCRIPTION
## Summary
- `validate.ts`: new r034 warning fires when confidence ≥50% + directional/mixed bias + zero setups, but the analysis text contains no structural level rejection documentation (`poor RR`, `conflicting timeframe`, `insufficient confluence`, etc.)
- `axiom.ts`: `validate.ts` added to `ALWAYS_INJECT` — AXIOM can now read the validation code and write precise `codeChange` instructions targeting it in future sessions
- Closes self-task #52

## Why both together
Without `ALWAYS_INJECT`, AXIOM could see the r034 warning fire in its session context but couldn't write a targeted fix because it couldn't see `validate.ts` contents. With both changes, AXIOM gets the warning AND the file — closing the loop that caused 4 consecutive sessions of acknowledged-but-unacted gaps.

## Test plan
- [ ] 141/141 tests pass (`vitest run tests/validate.test.ts tests/axiom.test.ts`)
- [ ] 7 new r034 tests: trigger conditions, rejection doc variants, boundary cases (confidence <50, neutral bias, setups present)
- [ ] `tsc --noEmit` clean