### PR TITLE
fix(self-tasks,axiom): dynamic injection title + dedup recently-closed issues

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -406,11 +406,16 @@ export function parseAxiomResponse(
     );
     if (!alreadyHasRuleGap) {
       console.warn("  ⚠ Axiom: compliance violation acknowledged without action — injecting forced self-task");
+      // Build title from first sentence of whatFailed so the task describes the actual gap,
+      // not a stale hardcoded r029 label that may already be resolved.
+      const failText = (rawParsed.whatFailed ?? "").trim();
+      const firstSentence = failText.split(/[.!?]/)[0].trim().slice(0, 80);
+      const taskTitle = firstSentence || "Recurring execution gap: compliance violation acknowledged without action";
       parsed.newSelfTasks = [
         ...(parsed.newSelfTasks ?? []),
         {
-          title: "Enforce stop distance validation at ORACLE output layer (r029)",
-          body: "AXIOM acknowledged a compliance violation but created no rule update or self-task to address it. Add hard filtering in validate.ts to remove setups that violate r029 minimum stop distance requirements during elevated volatility sessions, rather than just warning.",
+          title: taskTitle,
+          body: `AXIOM acknowledged a compliance violation but created no rule update, new rule, or self-task to address it.\n\nSpecific failure identified:\n> "${failText.slice(0, 500)}"\n\nResolve by: (1) adding a code-level validation gate in validate.ts or agent.ts, (2) writing a rule that can be mechanically checked, or (3) explicitly accepting this as a known limitation and closing this issue.`,
           category: "rule-gap",
           priority: "high",
         },

--- a/src/self-tasks.ts
+++ b/src/self-tasks.ts
@@ -75,13 +75,53 @@ export function setCachedOpenTasks(tasks: OpenSelfTask[]): void {
   _cachedOpenTasks = tasks;
 }
 
+// ── Fetch recently-closed self-tasks for dedup ─────────────
+// Prevents re-opening issues that were closed in the last N days.
+// Called only during createSelfTask so the extra API hit is rare.
+
+async function fetchRecentlyClosedSelfTasks(days = 30): Promise<OpenSelfTask[]> {
+  const repo    = getRepo();
+  const headers = getHeaders();
+  const since   = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repo}/issues?labels=nexus-self-task&state=closed&since=${since}&per_page=20`,
+      { headers, signal: AbortSignal.timeout(20000) }
+    );
+    if (!res.ok) return [];
+
+    const data = await res.json() as any[];
+    return data
+      .filter((i: any) => !i.pull_request)
+      .map((i: any) => {
+        const categoryLabel = i.labels
+          .map((l: any) => l.name)
+          .find((n: string) => ["blind-spot","bias","rule-gap","new-concept","correlation"].includes(n)) ?? "unknown";
+        return {
+          number:        i.number,
+          title:         sanitizeUnicode(i.title.replace(/[\u{1F300}-\u{1FFFF}][\uFE0F]?\s?\[SELF-TASK\]\s?/u, "")),
+          body:          sanitizeUnicode((i.body ?? "").slice(0, 1500)),
+          category:      categoryLabel,
+          sessionOpened: 0,
+          url:           i.html_url,
+        };
+      });
+  } catch (err) {
+    console.warn(`  ⚠ Could not fetch recently closed self-tasks: ${err}`);
+    return [];
+  }
+}
+
 export async function createSelfTask(
   task: SelfTask,
   sessionNumber: number
 ): Promise<number | null> {
-  // Dedup: skip if a similar task already exists
-  const existing = _cachedOpenTasks ?? await fetchOpenSelfTasks();
-  if (isDuplicate(task.title, existing)) {
+  // Dedup: skip if a similar open OR recently-closed task exists.
+  // Checking closed tasks prevents re-opening issues that were just resolved.
+  const open         = _cachedOpenTasks ?? await fetchOpenSelfTasks();
+  const recentClosed = await fetchRecentlyClosedSelfTasks();
+  if (isDuplicate(task.title, [...open, ...recentClosed])) {
     console.log(`    ⏭ Skipped duplicate self-task: "${task.title}"`);
     return null;
   }

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -334,6 +334,23 @@ describe("parseAxiomResponse forced self-task injection", () => {
     expect(result.newSelfTasks.some((t: any) => t.category === "rule-gap")).toBe(true);
   });
 
+  it("uses first sentence of whatFailed as the injected task title", () => {
+    const json = JSON.stringify({
+      whatWorked: "Good analysis",
+      whatFailed: "Systematic failure to screen commodities asset class. Oil was mentioned but no structural level evaluation documented.",
+      cognitiveBiases: ["anchoring bias"],
+      evolutionSummary: "Execution gap on commodities screening",
+      ruleUpdates: [], newRules: [], systemPromptAdditions: "",
+      newSelfTasks: [], resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 150, rules);
+    const injected = (result.newSelfTasks ?? []).find((t: any) => t.category === "rule-gap");
+    expect(injected).toBeDefined();
+    expect(injected.title).toContain("Systematic failure to screen commodities");
+    expect(injected.title).not.toContain("r029");
+    expect(injected.body).toContain("Oil was mentioned");
+  });
+
   it("does not inject self-task when rule update accompanies the violation acknowledgement", () => {
     const json = JSON.stringify({
       whatWorked: "Good analysis",
@@ -346,7 +363,7 @@ describe("parseAxiomResponse forced self-task injection", () => {
     });
     const result = parseAxiomResponse(json, 150, rules);
     // No forced injection since a rule update is present
-    const forcedCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap" && /stop|r029/i.test(t.title ?? "")).length;
+    const forcedCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap").length;
     expect(forcedCount).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- `axiom.ts`: replaces hardcoded r029 text in the forced self-task injector with a dynamic title/body derived from AXIOM's actual `whatFailed` first sentence — no more stale r029 labels on unrelated gaps
- `self-tasks.ts`: `createSelfTask` now checks recently-closed issues (last 30 days) in addition to open issues before creating — prevents re-opening resolved tasks (root cause of #56 duplicating #53)

## Root cause of #56
`detectAxiomRumination` fired in session #159 (AXIOM had no rule changes), injected the hardcoded r029 task, and dedup didn't block it because #53 was already closed. Two independent bugs, both fixed here.

## Test plan
- [ ] 38/38 tests pass (`vitest run tests/axiom.test.ts tests/self-tasks.test.ts`)
- [ ] New test: injected task title contains first sentence of `whatFailed`, not "r029"
- [ ] Updated test: drops brittle `/r029/i` title check, uses `category === "rule-gap"` instead
- [ ] `tsc --noEmit` clean