### PR TITLE
fix(validate): raw confidence for r034/r026/r038, add r038 code enforcement

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -302,26 +302,32 @@ export function validateOracleOutput(
     }
   }
 
+  // Use the higher of calibrated confidence or raw text-extracted confidence for threshold
+  // checks. Calibration can reduce 69% → 49%, silently bypassing checks that should fire.
+  // Raw confidence is extracted from the analysis text (e.g. "Confidence: 69%").
+  const rawConfidence = extractConfidenceFromText(oracle.analysis ?? "") ?? oracle.confidence;
+  const effectiveConfidence = Math.max(
+    typeof oracle.confidence === "number" ? oracle.confidence : 0,
+    rawConfidence
+  );
+
   // r026: high confidence must produce broad setup coverage
-  // When confidence > 55%, fewer than 3 setups indicates incomplete screening.
+  // When effective confidence > 55%, fewer than 3 setups indicates incomplete screening.
   // Analytics show this is the most common cause of hit rate underperformance
   // in the 50-85% confidence bands.
-  if (typeof oracle.confidence === "number" && oracle.confidence > 55) {
+  if (effectiveConfidence > 55) {
     const setupCount = oracle.setups?.length ?? 0;
     if (setupCount < 3) {
       warnings.push(
-        `r026: confidence ${oracle.confidence}% with only ${setupCount} setup(s) — high-confidence sessions require systematic screening across all available instruments (minimum 3 setups)`
+        `r026: confidence ${effectiveConfidence}% with only ${setupCount} setup(s) — high-confidence sessions require systematic screening across all available instruments (minimum 3 setups)`
       );
     }
   }
 
   // r034: zero setups with directional/mixed confidence requires level rejection documentation.
-  // When confidence ≥50% and bias is not neutral, producing zero setups is only acceptable
-  // if the analysis explicitly documents which levels were evaluated and why each was rejected.
-  // Without that documentation, zero setups = undetectable screening failure.
+  // Uses effective (raw) confidence so calibration cannot bypass this check.
   if (
-    typeof oracle.confidence === "number" &&
-    oracle.confidence >= 50 &&
+    effectiveConfidence >= 50 &&
     oracle.bias?.overall !== "neutral" &&
     (oracle.setups?.length ?? 0) === 0
   ) {
@@ -334,10 +340,39 @@ export function validateOracleOutput(
     const hasRejectionDoc = rejectionMarkers.some(p => analysisLower.includes(p));
     if (!hasRejectionDoc) {
       warnings.push(
-        `r034: ${oracle.confidence}% confidence with ${oracle.bias?.overall} bias produced zero setups ` +
+        `r034: ${effectiveConfidence}% confidence with ${oracle.bias?.overall} bias produced zero setups ` +
         `but analysis contains no structural level evaluation or rejection reasoning — ` +
         `document which levels were screened and why each was rejected (poor RR, conflicting timeframe, insufficient confluence)`
       );
+    }
+  }
+
+  // r038: high-conviction sessions require proportional output or documented evaluation.
+  // When effective confidence ≥60% with directional/mixed bias, must produce either
+  // (1) minimum 2 setups across different asset classes, or (2) evidence in the analysis
+  // text that at least 5 specific instruments were evaluated.
+  // Uses effective confidence so post-calibration capping cannot bypass this check.
+  if (
+    effectiveConfidence >= 60 &&
+    oracle.bias?.overall !== "neutral"
+  ) {
+    const setupCount = oracle.setups?.length ?? 0;
+    if (setupCount < 2) {
+      // Check if analysis documents evaluation of ≥5 instruments by name
+      // (instrument names typically appear as ticker or common name patterns)
+      const instrumentMentions = (oracle.marketSnapshots ?? []).filter(snap => {
+        const name   = snap.name.toLowerCase();
+        const symbol = snap.symbol.toLowerCase().replace(/[^a-z]/g, "");
+        const text   = (oracle.analysis ?? "").toLowerCase();
+        return text.includes(name) || text.includes(symbol);
+      }).length;
+      if (instrumentMentions < 5) {
+        warnings.push(
+          `r038: ${effectiveConfidence}% confidence with ${oracle.bias?.overall} bias produced only ${setupCount} setup(s) ` +
+          `and analysis references only ${instrumentMentions} instrument(s) — ` +
+          `high-conviction sessions require minimum 2 setups or documented evaluation of ≥5 instruments`
+        );
+      }
     }
   }
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -439,6 +439,80 @@ describe("validateOracleOutput r034 zero-setup check", () => {
     );
     expect(result.warnings.some((w) => w.includes("r034"))).toBe(false);
   });
+
+  it("fires when calibrated confidence is 49 but raw text confidence is 69 (session #160 scenario)", () => {
+    const result = validateOracleOutput(
+      makeZeroSetupOracle({
+        confidence: 49,
+        analysis: "Confidence: 69% — TC (65%), MA (75%), RR (70%). Major coordinated rally.",
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r034"))).toBe(true);
+  });
+});
+
+// ── r038: high-conviction proportional output check ─────────────
+
+describe("validateOracleOutput r038 high-conviction check", () => {
+  function makeHighConfOracle(overrides: Partial<OracleAnalysis> = {}): OracleAnalysis {
+    return {
+      sessionId: "test",
+      timestamp: new Date().toISOString(),
+      analysis: "Confidence: 69% — TC (65%), MA (75%), RR (70%). NASDAQ surged. EUR/USD rallied. GBP/USD up. Bitcoin strong.",
+      bias: { overall: "bullish", notes: "risk-on" },
+      confidence: 49, // calibrated down from 69
+      setups: [],
+      keyLevels: [],
+      marketSnapshots: [
+        { symbol: "NQ=F", name: "nasdaq", category: "indices", price: 20000, previousClose: 19000, change: 1000, changePercent: 5.26, high: 20100, low: 19000, timestamp: "" },
+        { symbol: "EURUSD=X", name: "eur/usd", category: "forex", price: 1.18, previousClose: 1.17, change: 0.01, changePercent: 0.85, high: 1.18, low: 1.17, timestamp: "" },
+        { symbol: "GBPUSD=X", name: "gbp/usd", category: "forex", price: 1.36, previousClose: 1.35, change: 0.01, changePercent: 0.74, high: 1.36, low: 1.35, timestamp: "" },
+        { symbol: "BTC-USD", name: "bitcoin", category: "crypto", price: 75000, previousClose: 73000, change: 2000, changePercent: 2.74, high: 75500, low: 73000, timestamp: "" },
+      ],
+      assumptions: [],
+      ...overrides,
+    };
+  }
+
+  it("warns when raw confidence >= 60 and only 1 setup and fewer than 5 instruments mentioned", () => {
+    const result = validateOracleOutput(
+      makeHighConfOracle({
+        setups: [{ instrument: "EUR/USD", type: "FVG", direction: "bullish", entry: 1.18, stop: 1.17, target: 1.20, RR: 2, timeframe: "1H" }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r038"))).toBe(true);
+  });
+
+  it("does not warn when 2+ setups present", () => {
+    const result = validateOracleOutput(
+      makeHighConfOracle({
+        setups: [
+          { instrument: "EUR/USD", type: "FVG", direction: "bullish", entry: 1.18, stop: 1.17, target: 1.20, RR: 2, timeframe: "1H" },
+          { instrument: "Bitcoin", type: "MSS", direction: "bullish", entry: 75000, stop: 73000, target: 78000, RR: 1.5, timeframe: "4H" },
+        ],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r038"))).toBe(false);
+  });
+
+  it("does not warn when bias is neutral", () => {
+    const result = validateOracleOutput(
+      makeHighConfOracle({ bias: { overall: "neutral", notes: "" } }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r038"))).toBe(false);
+  });
+
+  it("does not warn when raw confidence < 60", () => {
+    const result = validateOracleOutput(
+      makeHighConfOracle({ confidence: 45, analysis: "Confidence: 58% — TC (55%), MA (60%), RR (60%). Some analysis." }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r038"))).toBe(false);
+  });
 });
 
 // ── extractConfidenceFromText ────────────────────────────────


### PR DESCRIPTION
## Summary
- `validateOracleOutput` now computes `effectiveConfidence = max(calibrated, rawFromText)` — calibration capping 69%→49% can no longer silently bypass threshold checks (root cause of session #160 zero-setup gap being missed)
- r026 and r034 now use `effectiveConfidence` instead of `oracle.confidence`
- New r038 check: when effective confidence ≥60% + directional/mixed bias + <2 setups, warns if analysis references fewer than 5 instruments — enforces the rule AXIOM added in session #160

## Root cause (session #160)
ORACLE calculated 69% confidence internally but calibration capped it to 49%. Both r034 and r026 used `oracle.confidence` (49%), so neither warning fired despite a clear high-conviction zero-setup session.

## Test plan
- [ ] 113/113 tests pass (`vitest run tests/validate.test.ts`)
- [ ] New test: r034 fires when calibrated=49 but raw text says 69% (session #160 case)
- [ ] New tests: r038 trigger, exempt when 2+ setups, neutral bias, raw <60%
- [ ] `tsc --noEmit` clean