### PR TITLE
feat(validate): enforce r039 cross-asset screening gate

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -376,6 +376,46 @@ export function validateOracleOutput(
     }
   }
 
+  // r039: coordinated market cross-asset screening.
+  // When effective confidence ≥55% during coordinated moves (3+ asset classes each with
+  // at least one instrument moving >2%), setups must span ≥2 asset classes or each
+  // non-covered class must be explicitly rejected with quantified reasoning.
+  if (effectiveConfidence >= 55 && oracle.bias?.overall !== "neutral") {
+    const classifyInstrument = (name: string, symbol: string): string => {
+      const n = (name ?? "").toLowerCase();
+      const s = (symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
+      const cryptoTokens = ["bitcoin","ethereum","btc","eth","bnb","sol","ada","dot","link","xrp","matic","avax","cardano","polkadot","chainlink"];
+      const indexTokens  = ["nasdaq","nas100","s&p","spx","dow","djia","dax","ftse","nikkei","cac","ibex","russell"];
+      const commodTokens = ["gold","silver","oil","crude","copper","natgas","wheat","platinum","xau","xag"];
+      if (cryptoTokens.some(t => n.includes(t) || s.includes(t))) return "crypto";
+      if (indexTokens.some(t => n.includes(t) || s.includes(t)))  return "indices";
+      if (commodTokens.some(t => n.includes(t) || s.includes(t))) return "commodities";
+      return "forex";
+    };
+
+    const snapshots = oracle.marketSnapshots ?? [];
+    const classesWithBigMoves = new Set<string>();
+    for (const snap of snapshots) {
+      if (Math.abs(snap.changePercent) >= 2) {
+        classesWithBigMoves.add(classifyInstrument(snap.name, snap.symbol));
+      }
+    }
+
+    if (classesWithBigMoves.size >= 3) {
+      const setupClasses = new Set<string>();
+      for (const s of oracle.setups ?? []) {
+        setupClasses.add(classifyInstrument(s.instrument ?? "", s.instrument ?? ""));
+      }
+      if (setupClasses.size < 2) {
+        const coveredLabel = setupClasses.size === 0 ? "no" : `only ${[...setupClasses][0]}`;
+        warnings.push(
+          `r039: ${effectiveConfidence}% confidence with ${classesWithBigMoves.size} asset classes moving >2% — ` +
+          `setups cover ${coveredLabel} asset class(es); screening must span multiple classes or explicitly reject each with quantified reasoning (poor RR <1.3, stop >2%, conflicting timeframes)`
+        );
+      }
+    }
+  }
+
   // "Other" type overuse — ICT types should be preferred
   if (oracle.setups && oracle.setups.length > 0) {
     const otherCount = oracle.setups.filter(s => s.type === "Other").length;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -515,6 +515,89 @@ describe("validateOracleOutput r038 high-conviction check", () => {
   });
 });
 
+// ── r039: coordinated market cross-asset screening check ─────
+
+describe("validateOracleOutput r039 cross-asset screening check", () => {
+  const coordinatedSnapshots = [
+    { name: "EUR/USD",     symbol: "EURUSD",  price: 1.18,   changePercent: 2.5,  volume: 1000 },
+    { name: "GBP/USD",     symbol: "GBPUSD",  price: 1.35,   changePercent: 3.1,  volume: 1000 },
+    { name: "NASDAQ 100",  symbol: "NAS100",  price: 19000,  changePercent: 6.6,  volume: 5000 },
+    { name: "S&P 500",     symbol: "SPX",     price: 5500,   changePercent: 5.2,  volume: 5000 },
+    { name: "Gold",        symbol: "XAUUSD",  price: 4860,   changePercent: 2.1,  volume: 2000 },
+    { name: "Bitcoin",     symbol: "BTCUSD",  price: 74695,  changePercent: 2.35, volume: 8000 },
+    { name: "Ethereum",    symbol: "ETHUSD",  price: 2336,   changePercent: 4.06, volume: 6000 },
+  ];
+
+  function makeR039Oracle(overrides: Partial<OracleAnalysis> = {}): OracleAnalysis {
+    return {
+      sessionId: "test",
+      timestamp: new Date().toISOString(),
+      analysis: "Confidence: 58% — TC (60%), MA (55%), RR (60%). Broad USD weakness with indices surging.",
+      bias: { overall: "mixed", notes: "coordinated risk-on across 4 asset classes" },
+      confidence: 38, // calibrated down from 58
+      setups: [
+        { instrument: "Bitcoin", type: "MSS", direction: "bullish", entry: 74695, stop: 73500, target: 76500, RR: 1.51, timeframe: "4H" },
+        { instrument: "Ethereum", type: "MSS", direction: "bullish", entry: 2336, stop: 2280, target: 2420, RR: 1.5, timeframe: "4H" },
+      ],
+      marketSnapshots: coordinatedSnapshots,
+      keyLevels: [],
+      assumptions: ["USD weakness attribution unconfirmed"],
+      ...overrides,
+    } as OracleAnalysis;
+  }
+
+  it("warns when raw confidence >=55, 3+ classes moving >2%, and setups cover only one asset class", () => {
+    const result = validateOracleOutput(makeR039Oracle(), []);
+    expect(result.warnings.some((w) => w.includes("r039"))).toBe(true);
+  });
+
+  it("does not warn when setups span 2+ asset classes", () => {
+    const result = validateOracleOutput(
+      makeR039Oracle({
+        setups: [
+          { instrument: "Bitcoin", type: "MSS", direction: "bullish", entry: 74695, stop: 73500, target: 76500, RR: 1.51, timeframe: "4H" },
+          { instrument: "EUR/USD", type: "FVG", direction: "bullish", entry: 1.18, stop: 1.17, target: 1.20, RR: 2, timeframe: "1H" },
+        ],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r039"))).toBe(false);
+  });
+
+  it("does not warn when fewer than 3 asset classes have moves >2%", () => {
+    const fewClassSnapshots = [
+      { name: "EUR/USD", symbol: "EURUSD", price: 1.18,  changePercent: 2.5,  volume: 1000 },
+      { name: "Bitcoin", symbol: "BTCUSD", price: 74695, changePercent: 2.35, volume: 8000 },
+      { name: "Gold",    symbol: "XAUUSD", price: 4860,  changePercent: 0.5,  volume: 2000 }, // flat
+      { name: "NASDAQ",  symbol: "NAS100", price: 19000, changePercent: 0.8,  volume: 5000 }, // flat
+    ];
+    const result = validateOracleOutput(
+      makeR039Oracle({ marketSnapshots: fewClassSnapshots }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r039"))).toBe(false);
+  });
+
+  it("does not warn when effective confidence is below 55", () => {
+    const result = validateOracleOutput(
+      makeR039Oracle({
+        confidence: 38,
+        analysis: "Confidence: 53% — TC (50%), MA (55%), RR (55%). Broad USD weakness.",
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r039"))).toBe(false);
+  });
+
+  it("does not warn when bias is neutral", () => {
+    const result = validateOracleOutput(
+      makeR039Oracle({ bias: { overall: "neutral", notes: "" } }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r039"))).toBe(false);
+  });
+});
+
 // ── extractConfidenceFromText ────────────────────────────────
 
 describe("extractConfidenceFromText", () => {


### PR DESCRIPTION
## Summary
- Adds r039 validation check in `validateOracleOutput`: when `effectiveConfidence >= 55%` and 3+ asset classes each have an instrument moving >2%, warns if setups cover fewer than 2 asset classes
- Uses same `effectiveConfidence = max(calibrated, raw)` pattern as r038 so post-calibration downward adjustments can't bypass the check
- Adds `classifyInstrument` helper that maps instrument names/symbols to `crypto / indices / commodities / forex`

## Context
Session #161 (2026-04-14): AXIOM added r039 after identifying that 58% raw confidence with coordinated moves across 4 asset classes still produced crypto-only setups. This PR wires r039 into the validation layer — the same gap r038 had when it was first added in session #160.

## Test plan
- [x] 5 new tests in `tests/validate.test.ts` — positive case + 4 boundary conditions (setups span 2 classes, <3 classes moving, confidence <55, neutral bias)
- [x] All 118 validate tests pass
- [x] `tsc --noEmit` clean