### PR TITLE
fix(oracle,validate): remove programmatic confidence calibration

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -14,7 +14,7 @@ import {
   salvageJSON, stripSurrogates, extractJSONFromResponse, groupBy,
   MEMORY_DIR, SYSTEM_PROMPT_PATH, ANALYSIS_RULES_PATH,
 } from "./utils";
-import { resolveConfidence, applyCalibrationAdjustment } from "./validate";
+import { resolveConfidence } from "./validate";
 import { loadAllJournalEntries } from "./journal";
 import { buildCalibrationContext } from "./analytics";
 import type {
@@ -484,13 +484,6 @@ Only respond with the JSON array, no other text.`;
 
   // Resolve text vs JSON confidence mismatch
   let finalConfidence = resolveConfidence(parsed.analysis ?? "", parsed.confidence ?? 50);
-
-  // Apply programmatic calibration based on historical hit rate data
-  const preCalibration = finalConfidence;
-  finalConfidence = applyCalibrationAdjustment(finalConfidence, biasOverall);
-  if (finalConfidence !== preCalibration) {
-    console.log(`  📊 Calibration adjustment: ${preCalibration}% → ${finalConfidence}% (bias: ${biasOverall})`);
-  }
 
   // Enforce: high confidence with zero setups is contradictory
   if (finalConfidence > 60 && validSetups.length === 0) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -95,42 +95,6 @@ export function resolveConfidence(analysis: string, jsonConfidence: number): num
   return jsonConfidence;
 }
 
-// ── Programmatic Confidence Calibration ──────────────────────
-// Historical data shows confidence bands are miscalibrated:
-//   30-50% band: NEXUS claims ~40% → actual hit rate 57% (underconfident)
-//   50-70% band: NEXUS claims ~58% → actual hit rate 17% (severely overconfident)
-//   70-85% band: NEXUS claims ~75% → actual hit rate 40% (overconfident)
-// This function applies mathematical corrections post-ORACLE.
-
-export function applyCalibrationAdjustment(
-  rawConfidence: number,
-  biasOverall: string
-): number {
-  // Only adjust the miscalibrated bands (30-70)
-  // Outside these bands, not enough data to calibrate
-  if (rawConfidence < 30 || rawConfidence >= 70) {
-    return rawConfidence;
-  }
-
-  let adjusted = rawConfidence;
-
-  if (rawConfidence >= 50 && rawConfidence < 70) {
-    // 50-70% band: severely overconfident (claims 58%, actual 17%)
-    // Base penalty: reduce by 15 points
-    // Mixed bias gets extra penalty (correlation breakdown = even worse hit rate)
-    const basePenalty = 15;
-    const mixedExtra = biasOverall === "mixed" ? 5 : 0;
-    adjusted = rawConfidence - basePenalty - mixedExtra;
-  } else if (rawConfidence >= 30 && rawConfidence < 50) {
-    // 30-50% band: underconfident (claims 40%, actual 57%)
-    // Boost by 8 points to better reflect actual performance
-    adjusted = rawConfidence + 8;
-  }
-
-  // Clamp to valid range
-  return Math.round(Math.max(0, Math.min(100, adjusted)));
-}
-
 // ── Weekend Crypto Screening Validator ───────────────────
 // Checks which available crypto instruments ORACLE actually covered
 // (mentioned in analysis text or produced a setup for). Weekend sessions
@@ -302,9 +266,8 @@ export function validateOracleOutput(
     }
   }
 
-  // Use the higher of calibrated confidence or raw text-extracted confidence for threshold
-  // checks. Calibration can reduce 69% → 49%, silently bypassing checks that should fire.
-  // Raw confidence is extracted from the analysis text (e.g. "Confidence: 69%").
+  // Use the higher of oracle.confidence or text-extracted confidence for threshold checks.
+  // Guards against cases where ORACLE puts a lower number in the JSON than it stated in text.
   const rawConfidence = extractConfidenceFromText(oracle.analysis ?? "") ?? oracle.confidence;
   const effectiveConfidence = Math.max(
     typeof oracle.confidence === "number" ? oracle.confidence : 0,

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -837,55 +837,6 @@ describe("validateAxiomOutput bias-to-rule mapping", () => {
   });
 });
 
-// ── applyCalibrationAdjustment ────────────────────────────────
-
-describe("applyCalibrationAdjustment", () => {
-  // Import dynamically since we're adding it
-  let applyCalibrationAdjustment: typeof import("../src/validate").applyCalibrationAdjustment;
-
-  beforeAll(async () => {
-    const mod = await import("../src/validate");
-    applyCalibrationAdjustment = mod.applyCalibrationAdjustment;
-  });
-
-  it("reduces confidence in the 50-70% band during mixed bias", () => {
-    const result = applyCalibrationAdjustment(58, "mixed");
-    expect(result).toBeLessThan(50);
-    expect(result).toBeGreaterThanOrEqual(30);
-  });
-
-  it("reduces confidence in the 50-70% band for non-mixed bias too", () => {
-    const result = applyCalibrationAdjustment(60, "bullish");
-    expect(result).toBeLessThan(60);
-  });
-
-  it("boosts confidence in the 30-50% band", () => {
-    const result = applyCalibrationAdjustment(40, "bullish");
-    expect(result).toBeGreaterThan(40);
-    expect(result).toBeLessThanOrEqual(55);
-  });
-
-  it("applies stronger penalty for mixed bias in 50-70% band", () => {
-    const mixed = applyCalibrationAdjustment(60, "mixed");
-    const bullish = applyCalibrationAdjustment(60, "bullish");
-    expect(mixed).toBeLessThan(bullish);
-  });
-
-  it("does not adjust confidence below 30 or above 70", () => {
-    expect(applyCalibrationAdjustment(25, "bullish")).toBe(25);
-    expect(applyCalibrationAdjustment(75, "bearish")).toBe(75);
-  });
-
-  it("clamps results to 0-100 range", () => {
-    expect(applyCalibrationAdjustment(5, "bullish")).toBeGreaterThanOrEqual(0);
-    expect(applyCalibrationAdjustment(95, "bullish")).toBeLessThanOrEqual(100);
-  });
-
-  it("returns a whole number", () => {
-    const result = applyCalibrationAdjustment(55, "mixed");
-    expect(Number.isInteger(result)).toBe(true);
-  });
-});
 
 // ── resolveConfidence ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Removes `applyCalibrationAdjustment()` from `validate.ts` and its call site in `oracle.ts`
- Deletes 7 now-dead calibration tests from `validate.test.ts`

## Why
Calibration was post-hoc adjusting ORACLE's reported confidence (e.g. 57% → 37%) to correct for observed overconfidence in the 50-70% band. But it caused more problems than it solved:

1. **Permanent mismatch warning every session** — `validateOracleOutput` fired a confidence mismatch warning because text said 57% but JSON said 37%. AXIOM saw this every session, flagged it as "unresolved technical debt", and wasted reflection space on something it couldn't fix.
2. **Zero quality control benefit** — all validation threshold checks (r026/r034/r038/r039) already used `effectiveConfidence = max(calibrated, raw)`, so calibration was bypassed for every enforcement check anyway.
3. **AXIOM couldn't self-improve** — it could see "57%" in its own analysis but "37%" in the journal, with no explanation. This blocked meaningful confidence calibration through rule evolution.

The correct path is AXIOM learning to report accurate confidence through rules — r025, r038, and r039 are already pushing in this direction.

## Test plan
- [x] 111 validate tests pass (7 calibration tests deleted as dead code)
- [x] `tsc --noEmit` clean