### PR TITLE
fix: r040 enforcement, confidence display, rule proliferation

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -26,7 +26,7 @@ import {
   loadAllJournalEntries,
   saveJournalEntry,
 } from "./journal";
-import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, logFailure, loadRecentFailures } from "./validate";
+import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, logFailure, loadRecentFailures, resolveConfidence } from "./validate";
 import { buildAnalyticsSummary }                                    from "./analytics";
 import { fetchRSSNews, formatRSSForPrompt }                          from "./rss";
 import { notifySessionComplete }                                     from "./notifications";
@@ -534,6 +534,15 @@ export async function runAndValidateOracle(
       console.warn(`  ⚠ r029: removed setup [${r.instrument}] — ${r.reason}`);
     }
     oracle = filteredOracle;
+  }
+
+  // Resolve confidence discrepancy: if the analysis text states a higher confidence than
+  // the JSON field, use the text value so the journal records the correct number.
+  // This corrects cases where ORACLE writes inconsistent values (e.g. session #163: JSON=45, text=61).
+  const resolvedConfidence = resolveConfidence(oracle.analysis, oracle.confidence);
+  if (resolvedConfidence !== oracle.confidence) {
+    console.log(chalk.dim(`  ↳ Confidence resolved: ${oracle.confidence}% → ${resolvedConfidence}% (text-extracted value)`));
+    oracle = { ...oracle, confidence: resolvedConfidence };
   }
 
   // Print brief summary

--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -296,7 +296,7 @@ RULE POLICY — CRITICAL:
 - DO NOT create "meta-rules" that just enforce other rules. This includes: rules that reference another rule by ID (e.g. "deploy r012", "per r016"), rules that say "verify/check/ensure rule X is followed", and rules whose only purpose is to add process around an existing rule. That is validation logic, not an analysis rule. If you want validation, use codeChanges instead.
 - DO NOT create rules with words like MANDATORY, BLOCKING, INVALID, or MUST RESTART. Rules are guidelines, not kill switches.
 - DO NOT duplicate existing rules in different words. Before adding a rule, check your current rules list above.
-- If you have 25+ rules already, prefer modifying existing rules over adding new ones.
+- If you have 30+ rules already, you MUST modify an existing rule in the same category instead of adding a new one, unless the new rule covers a genuinely different enforcement mechanism not present in ANY existing rule. Before adding a rule, check: does any active rule already have the same "category" value (e.g. "setup_construction", "screening", "execution_accountability")? If yes, strengthen that rule rather than creating a near-duplicate. Categories with 2+ existing rules are saturated — adding more rules in the same category without code enforcement is rule bloat, not improvement.
 - COOLDOWN: You cannot modify a rule that was modified within the last 3 sessions. If you try, it will be blocked. Focus on other improvements instead.
 - Max rule length is 500 characters. Keep rules concise — one clear idea per rule.
 - Be surgical. Quality over quantity.`;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -157,6 +157,20 @@ export function validateWeekendCryptoScreening(
   return { covered, mentionedOnly, missing };
 }
 
+// ── Asset class classifier (shared by r039 and r040) ─────
+
+function classifyInstrument(name: string, symbol: string): string {
+  const n = (name ?? "").toLowerCase();
+  const s = (symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
+  const cryptoTokens = ["bitcoin","ethereum","btc","eth","bnb","sol","ada","dot","link","xrp","matic","avax","cardano","polkadot","chainlink"];
+  const indexTokens  = ["nasdaq","nas100","s&p","spx","dow","djia","dax","ftse","nikkei","cac","ibex","russell"];
+  const commodTokens = ["gold","silver","oil","crude","copper","natgas","wheat","platinum","xau","xag"];
+  if (cryptoTokens.some(t => n.includes(t) || s.includes(t))) return "crypto";
+  if (indexTokens.some(t => n.includes(t) || s.includes(t)))  return "indices";
+  if (commodTokens.some(t => n.includes(t) || s.includes(t))) return "commodities";
+  return "forex";
+}
+
 // ── ORACLE Validator ──────────────────────────────────────
 
 export function validateOracleOutput(
@@ -344,17 +358,6 @@ export function validateOracleOutput(
   // at least one instrument moving >2%), setups must span ≥2 asset classes or each
   // non-covered class must be explicitly rejected with quantified reasoning.
   if (effectiveConfidence >= 55 && oracle.bias?.overall !== "neutral") {
-    const classifyInstrument = (name: string, symbol: string): string => {
-      const n = (name ?? "").toLowerCase();
-      const s = (symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
-      const cryptoTokens = ["bitcoin","ethereum","btc","eth","bnb","sol","ada","dot","link","xrp","matic","avax","cardano","polkadot","chainlink"];
-      const indexTokens  = ["nasdaq","nas100","s&p","spx","dow","djia","dax","ftse","nikkei","cac","ibex","russell"];
-      const commodTokens = ["gold","silver","oil","crude","copper","natgas","wheat","platinum","xau","xag"];
-      if (cryptoTokens.some(t => n.includes(t) || s.includes(t))) return "crypto";
-      if (indexTokens.some(t => n.includes(t) || s.includes(t)))  return "indices";
-      if (commodTokens.some(t => n.includes(t) || s.includes(t))) return "commodities";
-      return "forex";
-    };
 
     const snapshots = oracle.marketSnapshots ?? [];
     const classesWithBigMoves = new Set<string>();
@@ -374,6 +377,38 @@ export function validateOracleOutput(
         warnings.push(
           `r039: ${effectiveConfidence}% confidence with ${classesWithBigMoves.size} asset classes moving >2% — ` +
           `setups cover ${coveredLabel} asset class(es); screening must span multiple classes or explicitly reject each with quantified reasoning (poor RR <1.3, stop >2%, conflicting timeframes)`
+        );
+      }
+    }
+  }
+
+  // r040: validation accountability — high-confidence sessions require cross-asset setup
+  // diversity OR documented price-level rejection with quantified reasons.
+  // Distinct from r038: r040 requires setups from DIFFERENT asset classes (not just any 2),
+  // and requires quantified rejection reasons (not just instrument mentions).
+  if (effectiveConfidence >= 60 && oracle.bias?.overall !== "neutral") {
+    const setupClasses = new Set<string>();
+    for (const s of oracle.setups ?? []) {
+      setupClasses.add(classifyInstrument(s.instrument ?? "", s.instrument ?? ""));
+    }
+    const crossAssetCoverage = setupClasses.size >= 2;
+
+    if (!crossAssetCoverage) {
+      const analysisLower = (oracle.analysis ?? "").toLowerCase();
+      const quantifiedRejectionKeywords = [
+        "poor rr", "rr <1.3", "rr<1.3", "stop distance", "stop >2%",
+        "conflicting higher timeframe", "conflicting timeframe", "rejected at",
+        "no viable entry", "insufficient confluence",
+      ];
+      const matchedKeywords = quantifiedRejectionKeywords.filter(kw => analysisLower.includes(kw));
+      const hasQuantifiedRejection = matchedKeywords.length >= 2;
+
+      if (!hasQuantifiedRejection) {
+        const setupClassLabel = setupClasses.size === 0 ? "no" : `only ${[...setupClasses].join("/")}`;
+        warnings.push(
+          `r040: ${effectiveConfidence}% confidence with ${oracle.bias?.overall} bias — setups cover ${setupClassLabel} asset class(es); ` +
+          `requires either (1) ≥2 setups across different asset classes, or (2) documented rejection of ≥5 specific price levels ` +
+          `with quantified reasons (poor RR <1.3, stop >2%, conflicting timeframe) across forex/indices/crypto`
         );
       }
     }

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -598,6 +598,100 @@ describe("validateOracleOutput r039 cross-asset screening check", () => {
   });
 });
 
+// ── r040: validation accountability — cross-asset setup diversity ─────────
+
+describe("validateOracleOutput r040 cross-asset validation accountability", () => {
+  const coordinatedSnapshots = [
+    { name: "EUR/USD",    symbol: "EURUSD",  price: 1.18,   changePercent: 0.94,  volume: 1000 },
+    { name: "GBP/USD",    symbol: "GBPUSD",  price: 1.36,   changePercent: 1.20,  volume: 1000 },
+    { name: "NASDAQ 100", symbol: "NAS100",  price: 25800,  changePercent: 6.39,  volume: 5000 },
+    { name: "S&P 500",    symbol: "SPX",     price: 5700,   changePercent: 5.04,  volume: 5000 },
+    { name: "Gold",       symbol: "XAUUSD",  price: 4867,   changePercent: 1.40,  volume: 2000 },
+    { name: "Bitcoin",    symbol: "BTCUSD",  price: 75886,  changePercent: 1.52,  volume: 8000 },
+    { name: "Polkadot",   symbol: "DOTUSD",  price: 1.15,   changePercent: -11.68, volume: 3000 },
+  ];
+
+  function makeR040Oracle(overrides: Partial<OracleAnalysis> = {}): OracleAnalysis {
+    return {
+      sessionId: "test",
+      timestamp: new Date().toISOString(),
+      // Session #163 scenario: 61% raw confidence, analysis mentions many instruments but no quantified rejection
+      analysis: "Confidence: 61% — TC (65%), MA (55%), RR (60%). Risk assets showing exceptional coordinated rally with NASDAQ +6.39%, S&P 500 +5.04%, EUR/USD +0.94%, GBP/USD +1.20%. Gold +1.40% alongside equity rally. Bitcoin +1.52%, ADA -5.31%, DOT -11.68%.",
+      bias: { overall: "mixed", notes: "risk asset rally with USD weakness but oil collapse and crypto divergence" },
+      confidence: 45, // calibrated down from 61
+      setups: [
+        { instrument: "Polkadot", type: "MSS", direction: "bearish", entry: 1.15, stop: 1.23, target: 1.045, RR: 1.31, timeframe: "4H" },
+      ],
+      marketSnapshots: coordinatedSnapshots,
+      keyLevels: [],
+      assumptions: ["Inflation data triggered USD weakness - unconfirmed"],
+      ...overrides,
+    } as OracleAnalysis;
+  }
+
+  it("warns when confidence >=60, non-neutral bias, single-asset-class setups, no quantified rejection docs", () => {
+    // Session #163 scenario: 1 crypto setup, 61% effective confidence, no rejection language
+    const result = validateOracleOutput(makeR040Oracle(), []);
+    expect(result.warnings.some((w) => w.includes("r040"))).toBe(true);
+  });
+
+  it("does not warn when setups span 2+ different asset classes", () => {
+    const result = validateOracleOutput(
+      makeR040Oracle({
+        setups: [
+          { instrument: "Polkadot", type: "MSS", direction: "bearish", entry: 1.15, stop: 1.23, target: 1.045, RR: 1.31, timeframe: "4H" },
+          { instrument: "EUR/USD",  type: "FVG", direction: "bullish", entry: 1.18, stop: 1.17, target: 1.20, RR: 2, timeframe: "1H" },
+        ],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r040"))).toBe(false);
+  });
+
+  it("does not warn when analysis contains quantified rejection reasoning", () => {
+    const result = validateOracleOutput(
+      makeR040Oracle({
+        analysis:
+          "Confidence: 61% — TC (65%), MA (55%), RR (60%). EUR/USD at 1.18 rejected — poor RR <1.3 with wide spread. GBP/USD at 1.36 rejected — conflicting timeframe on daily. NASDAQ at 25800 rejected — stop >2% required. Gold at 4867 rejected — insufficient confluence. S&P at 5700 rejected — poor RR <1.3. Only DOT viable.",
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r040"))).toBe(false);
+  });
+
+  it("does not warn when effective confidence is below 60", () => {
+    const result = validateOracleOutput(
+      makeR040Oracle({
+        confidence: 45,
+        analysis: "Confidence: 58% — TC (55%), MA (60%), RR (60%). Some analysis text here.",
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r040"))).toBe(false);
+  });
+
+  it("does not warn when bias is neutral", () => {
+    const result = validateOracleOutput(
+      makeR040Oracle({ bias: { overall: "neutral", notes: "" } }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r040"))).toBe(false);
+  });
+
+  it("still warns when 2 setups exist but both are in same asset class (crypto)", () => {
+    const result = validateOracleOutput(
+      makeR040Oracle({
+        setups: [
+          { instrument: "Polkadot", type: "MSS", direction: "bearish", entry: 1.15, stop: 1.23, target: 1.045, RR: 1.31, timeframe: "4H" },
+          { instrument: "Bitcoin",  type: "FVG", direction: "bullish", entry: 75000, stop: 73000, target: 78000, RR: 1.5, timeframe: "4H" },
+        ],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r040"))).toBe(true);
+  });
+});
+
 // ── extractConfidenceFromText ────────────────────────────────
 
 describe("extractConfidenceFromText", () => {


### PR DESCRIPTION
## Summary

- **r040 enforcement** (`validate.ts`): Extracted `classifyInstrument` to module level; added r040 validation check — warns when `effectiveConfidence ≥60` with non-neutral bias and setups don't span ≥2 different asset classes AND analysis lacks quantified rejection reasoning (poor RR <1.3, stop >2%, conflicting timeframe). Session #163 (1 crypto setup, 61% effective confidence, no rejection docs) would have triggered this. Mirrors the r038/r039 pattern.

- **Confidence display** (`agent.ts`): After `filterNonCompliantSetups`, now applies `resolveConfidence()` so the journal records the text-extracted confidence when ORACLE's JSON field diverges >10 points from the narrative. Session #163 showed JSON=45 vs text=61 — this fix corrects that discrepancy.

- **Rule proliferation** (`axiom.ts`): Tightened the guard from "25+ rules → prefer modifying" to "30+ rules → MUST modify same-category rule unless genuinely different mechanism". Added explicit guidance to check category duplicates before adding rules.

## Test plan

- [x] 6 new r040 tests: main warn path, cross-asset pass, quantified-rejection pass, low-confidence pass, neutral-bias pass, same-class-2-setups warn
- [x] All 472 existing tests pass
- [x] `tsc --noEmit` clean