### PR TITLE
fix: proportional confidence penalty, r031/r036/r041 enforcement, extended rumination detection

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -152,15 +152,21 @@ ${(() => {
   const raw = extractConfidenceFromText(oracle.analysis);
   if (raw !== null && raw !== oracle.confidence) {
     return `
-⚠️  CONFIDENCE CALIBRATION NOTICE — READ BEFORE REFLECTING ⚠️
-Your analysis text calculated ${raw}% confidence. The validation layer adjusted this to ${oracle.confidence}% based on historical hit-rate calibration. This adjustment is AUTOMATIC and CORRECT — it is not a rule execution failure on your part.
+⚠️  CONFIDENCE ADJUSTMENT NOTICE — READ BEFORE REFLECTING ⚠️
+Your analysis text calculated ${raw}% confidence. The pipeline adjusted this to ${oracle.confidence}%.
+
+This is an AUTOMATIC SYSTEM ENFORCEMENT — it is NOT a rule execution failure, output corruption, or evidence that your confidence methodology is broken.
+
+Possible reasons for the adjustment:
+1. Setup-count enforcement: you produced fewer setups than the minimum required for your confidence level (e.g. 3 setups at 67% confidence when 3 are required → no penalty; 3 setups at 75% when 4 are required → −10pts).
+2. Zero-setup contradiction: >60% confidence with 0 setups forces confidence to 35%.
 
 DO NOT:
-- Treat the ${raw}% → ${oracle.confidence}% difference as evidence that you "failed to apply r014 or r032"
-- Modify r014, r032, or any other confidence rules to "compensate" for this calibration
-- Write in whatFailed that your confidence methodology was inconsistently applied
+- Treat the ${raw}% → ${oracle.confidence}% difference as evidence that you "failed to apply r014 or r032" or that your "output mechanism is corrupted"
+- Modify r014, r032, or any other confidence rules to compensate for this adjustment
+- Write in whatFailed that your confidence methodology was inconsistently applied or that there is an "output mechanism failure"
 
-The calibration is working as designed. If you write about confidence in this reflection, acknowledge the calibration happened and move on.
+The pipeline enforcement is working as designed. Acknowledge it briefly and move on — focus your reflection on analytical quality, not on the number.
 `;
   }
   return "";
@@ -174,7 +180,7 @@ The calibration is working as designed. If you write about confidence in this re
 - Mixed bias justified: ${oracle.bias.overall !== "mixed" ? "N/A (bias is " + oracle.bias.overall + ")" : /conflict|divergen|breakdown/i.test(oracle.bias.notes) ? "YES" : "NO"}
 
 IMPORTANT ANTI-REPETITION RULES:
-- If a CONFIDENCE CALIBRATION NOTICE appeared above, you MUST NOT treat the calibration adjustment as a rule execution failure. Do not mention confidence methodology inconsistency in whatFailed. Do not modify r014 or r032.
+- If a CONFIDENCE ADJUSTMENT NOTICE appeared above, you MUST NOT treat the pipeline enforcement as a rule execution failure or "output mechanism corruption". Do not mention confidence methodology inconsistency in whatFailed. Do not modify r014 or r032.
 - Base your reflection on the compliance check above, not on assumptions from previous sessions.
 - If compliance says YES, acknowledge progress — do not repeat old criticisms.
 - BEFORE writing your reflection, review the "Recent session history" below. If your reflection would say the same thing as a previous session, you MUST either (a) find a genuinely NEW insight, or (b) say "No new insights this session — market conditions and analysis quality unchanged."

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -14,7 +14,7 @@ import {
   salvageJSON, stripSurrogates, extractJSONFromResponse, groupBy,
   MEMORY_DIR, SYSTEM_PROMPT_PATH, ANALYSIS_RULES_PATH,
 } from "./utils";
-import { resolveConfidence } from "./validate";
+import { resolveConfidence, applySetupCountPenalty } from "./validate";
 import { loadAllJournalEntries } from "./journal";
 import { buildCalibrationContext } from "./analytics";
 import type {
@@ -491,14 +491,12 @@ Only respond with the JSON array, no other text.`;
     finalConfidence = 35;
   }
 
-  // Enforce minimum setup counts based on confidence
-  const minSetups = isWeekend
-    ? 2
-    : finalConfidence > 60 ? 4 : finalConfidence > 50 ? 3 : 0;
-
-  if (minSetups > 0 && validSetups.length < minSetups) {
-    console.warn(`  \u26a0 ORACLE screening gap: ${validSetups.length} setups but minimum ${minSetups} required at ${finalConfidence}% confidence \u2014 reducing confidence to ${Math.min(finalConfidence, 45)}%`);
-    finalConfidence = Math.min(finalConfidence, 45);
+  // Enforce minimum setup counts based on confidence (proportional penalty, backlog #13)
+  const { penalized: penalizedConfidence, reason: penaltyReason } =
+    applySetupCountPenalty(finalConfidence, validSetups.length, isWeekend);
+  if (penaltyReason) {
+    console.warn(`  \u26a0 ORACLE ${penaltyReason}`);
+    finalConfidence = penalizedConfidence;
   }
 
   return {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -95,6 +95,39 @@ export function resolveConfidence(analysis: string, jsonConfidence: number): num
   return jsonConfidence;
 }
 
+// ── Setup count penalty (backlog #13) ────────────────────────
+// Applies a proportional confidence reduction when ORACLE produces fewer setups
+// than the minimum required for its stated confidence level.
+// Replaces the old hard-cap of Math.min(confidence, 45) which always produced
+// 45% regardless of how close to the threshold the session was.
+//
+// Thresholds (weekday):
+//   confidence > 70% → 4 setups required
+//   confidence > 50% → 3 setups required
+//   confidence ≤ 50% → no minimum
+// Weekend: always 2 setups minimum.
+// Penalty: 10 points per missing setup, floor at 35%.
+
+export function applySetupCountPenalty(
+  confidence: number,
+  setupCount: number,
+  isWeekend: boolean
+): { penalized: number; reason: string | null } {
+  const minSetups = isWeekend
+    ? 2
+    : confidence > 70 ? 4 : confidence > 50 ? 3 : 0;
+
+  if (minSetups > 0 && setupCount < minSetups) {
+    const shortfall = minSetups - setupCount;
+    const penalized = Math.max(35, confidence - shortfall * 10);
+    return {
+      penalized,
+      reason: `setup-count enforcement: ${setupCount}/${minSetups} required setups — confidence reduced from ${confidence}% by ${shortfall * 10}pts to ${penalized}%`,
+    };
+  }
+  return { penalized: confidence, reason: null };
+}
+
 // ── Weekend Crypto Screening Validator ───────────────────
 // Checks which available crypto instruments ORACLE actually covered
 // (mentioned in analysis text or produced a setup for). Weekend sessions
@@ -437,6 +470,78 @@ export function validateOracleOutput(
     }
   }
 
+  // r031: confidence > 65% requires cap notation in analysis text
+  if (effectiveConfidence > 65) {
+    const hasCapNotation = /capped from \d+%/i.test(oracle.analysis ?? "");
+    if (!hasCapNotation) {
+      warnings.push(
+        `r031: confidence ${effectiveConfidence}% exceeds 65% cap — analysis must include "capped from X% due to calibration discipline" notation per r031`
+      );
+    }
+  }
+
+  // r036: no bearish risk asset setups during active DXY weakness.
+  // DXY weakness = EUR/USD and GBP/USD both up >1% in the same session.
+  // Risk assets = indices and crypto (not forex, commodities).
+  {
+    const forexSnaps = (oracle.marketSnapshots ?? []).filter(s => {
+      const n = (s.name ?? "").toLowerCase().replace(/[^a-z/]/g, "");
+      const sym = (s.symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
+      return n.includes("eur") || n.includes("gbp") || sym.includes("eurusd") || sym.includes("gbpusd");
+    });
+    const eurUp  = forexSnaps.some(s => (s.name ?? "").toLowerCase().includes("eur") && (s.changePercent ?? 0) > 1);
+    const gbpUp  = forexSnaps.some(s => (s.name ?? "").toLowerCase().includes("gbp") && (s.changePercent ?? 0) > 1);
+    const dxyWeak = eurUp && gbpUp;
+
+    if (dxyWeak) {
+      const bearishRiskAssets = (oracle.setups ?? []).filter(s => {
+        const cls = classifyInstrument(s.instrument ?? "", s.instrument ?? "");
+        return s.direction === "bearish" && (cls === "indices" || cls === "crypto");
+      });
+      if (bearishRiskAssets.length > 0) {
+        warnings.push(
+          `r036: active DXY weakness (EUR/USD and GBP/USD both >+1%) — bearish risk asset setup(s) detected (${bearishRiskAssets.map(s => s.instrument).join(", ")}); r036 prohibits bearish risk asset setups when EUR/USD, GBP/USD, AUD/USD all up >1%`
+        );
+      }
+    }
+  }
+
+  // r041: when confidence >55%, analysis must mention all 8 mandatory screening instruments.
+  // Only fires on weekday sessions (detected by ≥4 of the 8 instruments in marketSnapshots).
+  if (effectiveConfidence > 55) {
+    const snapNames = new Set(
+      (oracle.marketSnapshots ?? []).flatMap(s => [
+        (s.name ?? "").toLowerCase(),
+        (s.symbol ?? "").toLowerCase().replace(/[^a-z]/g, ""),
+      ])
+    );
+    const r041Pairs: [string, string[]][] = [
+      ["EUR/USD",   ["eur/usd", "eurusd", "eur"]],
+      ["GBP/USD",   ["gbp/usd", "gbpusd", "gbp"]],
+      ["NASDAQ",    ["nasdaq", "nas100"]],
+      ["S&P",       ["s&p", "spx", "s&p500", "s&p 500"]],
+      ["BTC",       ["bitcoin", "btc"]],
+      ["ETH",       ["ethereum", "eth"]],
+      ["Gold",      ["gold", "xau"]],
+      ["Oil",       ["oil", "crude", "wti", "brent"]],
+    ];
+    // Only check pairs whose instruments are present in snapshots (weekday detection)
+    const presentPairs = r041Pairs.filter(([, aliases]) =>
+      aliases.some(a => [...snapNames].some(n => n.includes(a.replace("/", ""))))
+    );
+    if (presentPairs.length >= 4) {
+      const analysisLower = (oracle.analysis ?? "").toLowerCase();
+      const missing = presentPairs
+        .filter(([, aliases]) => !aliases.some(a => analysisLower.includes(a)))
+        .map(([name]) => name);
+      if (missing.length > 0) {
+        warnings.push(
+          `r041: ${effectiveConfidence}% confidence — pre-commitment screening requires mentioning all available instruments; missing from analysis: ${missing.join(", ")}`
+        );
+      }
+    }
+  }
+
   // r011 compliance: causal attribution language must be documented in assumptions[]
   // Catches both explicit causal phrases and softer attribution language ORACLE naturally uses
   const causalPattern = /\b(assuming|if confirmed|driven by|due to|because of|amid geopolit|escalation|de-escalation|suggests?|consistent with|appears? to|following\s+\w*day|amid\b|reflects?|indicates?)\b/i;
@@ -541,6 +646,9 @@ const VIOLATION_KEYWORDS = [
   "systematic failure", "failed to implement", "failed to comply",
   "failed to apply", "failed to execute", "violation", "non-compliant",
   "enforcement mechanisms are inadequate", "need validation logic", "need enforcement mechanism",
+  // Extended gap-acknowledgment patterns (backlog #6) — sessions #166-167
+  "remains a known gap", "known gap", "requires enforcement", "gap requiring enforcement",
+  "enforcement rather than", "requires code enforcement",
 ];
 
 export function detectAxiomRumination(parsed: {

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, detectAxiomRumination } from "../src/validate";
+import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, detectAxiomRumination, applySetupCountPenalty } from "../src/validate";
 import type { OracleAnalysis, JournalEntry } from "../src/types";
 
 // ── calculateTextSimilarity ─────────────────────────────────
@@ -1344,5 +1344,307 @@ describe("detectAxiomRumination — enforcement mechanism language", () => {
       newRules: [], newSelfTasks: [],
     });
     expect(result).toBeNull();
+  });
+
+  // ── Extended gap-acknowledgment patterns (backlog #6) ──────
+
+  it("detects 'remains a known gap' without action (session #167 pattern)", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "The screening accountability remains a known gap requiring enforcement rather than additional rules.",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("detects 'requires enforcement' without action", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "This gap requires enforcement at the code level rather than more rules.",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("detects 'known gap' phrase without action", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "This is a known gap that has persisted across multiple sessions.",
+      ruleUpdates: [], newRules: [], newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("does not flag 'known gap' when a self-task is created", () => {
+    const result = detectAxiomRumination({
+      whatFailed: "The screening gap remains a known gap requiring enforcement.",
+      ruleUpdates: [], newRules: [],
+      newSelfTasks: [{ title: "Fix screening enforcement", category: "rule-gap", priority: "high" }],
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ── applySetupCountPenalty (backlog #13) ─────────────────────
+
+describe("applySetupCountPenalty", () => {
+  it("returns unchanged confidence when setups meet the threshold for 51-70% confidence", () => {
+    // 67% confidence: threshold is 3 (>50 but <=70), has 3 setups → no penalty
+    const result = applySetupCountPenalty(67, 3, false);
+    expect(result.penalized).toBe(67);
+    expect(result.reason).toBeNull();
+  });
+
+  it("does NOT hard-cap to 45% — regression for sessions #166 and #167", () => {
+    // Under old code: 67% confidence, 3 setups → Math.min(67, 45) = 45. Must NOT happen.
+    const result = applySetupCountPenalty(67, 3, false);
+    expect(result.penalized).not.toBe(45);
+  });
+
+  it("returns unchanged confidence when confidence is 50 or below", () => {
+    const result = applySetupCountPenalty(45, 0, false);
+    expect(result.penalized).toBe(45);
+    expect(result.reason).toBeNull();
+  });
+
+  it("applies proportional penalty for 1 missing setup at >70% confidence", () => {
+    // 75% confidence needs 4 setups, has 3 → shortfall 1 → 75 - 10 = 65
+    const result = applySetupCountPenalty(75, 3, false);
+    expect(result.penalized).toBe(65);
+    expect(result.reason).not.toBeNull();
+  });
+
+  it("applies proportional penalty for 2 missing setups at >70% confidence", () => {
+    // 75% needs 4, has 2 → shortfall 2 → 75 - 20 = 55
+    const result = applySetupCountPenalty(75, 2, false);
+    expect(result.penalized).toBe(55);
+  });
+
+  it("does not reduce below 35%", () => {
+    // 75% needs 4, has 0 → shortfall 4 → Math.max(35, 75-40) = 35
+    const result = applySetupCountPenalty(75, 0, false);
+    expect(result.penalized).toBe(35);
+  });
+
+  it("weekend sessions require minimum 2 setups", () => {
+    // Weekend, 65% confidence, 1 setup → shortfall 1 → 65 - 10 = 55
+    const result = applySetupCountPenalty(65, 1, true);
+    expect(result.penalized).toBe(55);
+    expect(result.reason).not.toBeNull();
+  });
+
+  it("weekend sessions with 2 setups have no penalty", () => {
+    const result = applySetupCountPenalty(65, 2, true);
+    expect(result.penalized).toBe(65);
+    expect(result.reason).toBeNull();
+  });
+
+  it("weekend sessions with 0 required setups below threshold have no penalty", () => {
+    const result = applySetupCountPenalty(45, 0, true);
+    // Weekend min is always 2, so 0 setups at 45% → shortfall 2 → 45-20=25 → floor 35
+    // Actually weekend always requires 2, so this should penalize
+    expect(result.penalized).toBe(35);
+  });
+});
+
+// ── r031: confidence cap enforcement ─────────────────────────
+
+describe("validateOracleOutput r031 cap enforcement", () => {
+  function makeOracle31(confidence: number, analysis: string): OracleAnalysis {
+    return {
+      sessionId: "test", timestamp: new Date(),
+      analysis: analysis.padEnd(300, " "),
+      bias: { overall: "bullish", notes: "risk-on" },
+      confidence, setups: [], keyLevels: [], marketSnapshots: [], assumptions: [],
+    };
+  }
+
+  it("warns when confidence exceeds 65 with no cap notation", () => {
+    const result = validateOracleOutput(
+      makeOracle31(67, "Confidence: 67% — TC (70%), MA (65%), RR (60%). Strong bullish move."),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r031"))).toBe(true);
+  });
+
+  it("does not warn when confidence is exactly 65", () => {
+    const result = validateOracleOutput(
+      makeOracle31(65, "Confidence: 65% — TC (65%), MA (65%), RR (65%). Analysis here."),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);
+  });
+
+  it("does not warn when analysis contains cap notation", () => {
+    const result = validateOracleOutput(
+      makeOracle31(67, "Confidence: 70% — TC (70%), MA (70%), RR (70%). capped from 72% due to calibration discipline."),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);
+  });
+
+  it("does not warn when raw text confidence is also <= 65 (JSON field mismatch harmless)", () => {
+    const result = validateOracleOutput(
+      makeOracle31(45, "Confidence: 58% — TC (55%), MA (60%), RR (60%). Analysis."),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);
+  });
+});
+
+// ── r036: bearish risk asset during DXY weakness ─────────────
+
+describe("validateOracleOutput r036 DXY weakness check", () => {
+  function makeSnap(name: string, symbol: string, cat: string, changePercent: number) {
+    return { symbol, name, category: cat, price: 1.18, previousClose: 1.17, change: 0.01, changePercent, high: 1.19, low: 1.17, timestamp: new Date() };
+  }
+
+  const dxyWeaknessSnaps = [
+    makeSnap("EUR/USD", "EURUSD=X", "forex", 1.06),
+    makeSnap("GBP/USD", "GBPUSD=X", "forex", 1.20),
+    makeSnap("NASDAQ 100", "NQ=F", "indices", 5.3),
+  ];
+
+  function makeSetup(instrument: string, direction: "bullish" | "bearish") {
+    return {
+      instrument, type: "MSS" as const, direction, description: "test", invalidation: "test",
+      entry: direction === "bearish" ? 25000 : 1.18,
+      stop:  direction === "bearish" ? 25500 : 1.17,
+      target: direction === "bearish" ? 24000 : 1.20,
+      RR: 2, timeframe: "4H",
+    };
+  }
+
+  it("warns on bearish index setup during active DXY weakness (EUR + GBP both >1%)", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "USD weakness confirmed. NASDAQ extended at highs.".padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 58,
+      setups: [makeSetup("NASDAQ 100", "bearish")],
+      keyLevels: [], marketSnapshots: dxyWeaknessSnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r036"))).toBe(true);
+  });
+
+  it("warns on bearish crypto setup during active DXY weakness", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "DXY weakness. Bitcoin extended.".padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 58,
+      setups: [makeSetup("Bitcoin", "bearish")],
+      keyLevels: [], marketSnapshots: dxyWeaknessSnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r036"))).toBe(true);
+  });
+
+  it("does not warn on bullish risk asset setup during DXY weakness", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "DXY weakness confirmed, risk-on bias.".padEnd(300, " "),
+      bias: { overall: "bullish", notes: "risk-on" }, confidence: 58,
+      setups: [makeSetup("NASDAQ 100", "bullish")],
+      keyLevels: [], marketSnapshots: dxyWeaknessSnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r036"))).toBe(false);
+  });
+
+  it("does not warn when only EUR/USD is up >1% but GBP/USD is not", () => {
+    const partialSnaps = [
+      makeSnap("EUR/USD", "EURUSD=X", "forex", 1.10),
+      makeSnap("GBP/USD", "GBPUSD=X", "forex", 0.80),
+      makeSnap("NASDAQ 100", "NQ=F", "indices", 5.3),
+    ];
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "Mixed signals.".padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 58,
+      setups: [makeSetup("NASDAQ 100", "bearish")],
+      keyLevels: [], marketSnapshots: partialSnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r036"))).toBe(false);
+  });
+
+  it("does not warn on bearish forex setup during DXY weakness (forex is not a risk asset)", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "USD/CHF bearish on DXY weakness.".padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 58,
+      setups: [{
+        instrument: "USD/CHF", type: "MSS" as const, direction: "bearish" as const,
+        description: "test", invalidation: "test",
+        entry: 0.81, stop: 0.82, target: 0.79, RR: 2, timeframe: "4H",
+      }],
+      keyLevels: [], marketSnapshots: dxyWeaknessSnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r036"))).toBe(false);
+  });
+});
+
+// ── r041: pre-commitment instrument screening check ───────────
+
+describe("validateOracleOutput r041 pre-commitment check", () => {
+  const weekdaySnaps = [
+    { symbol: "EURUSD=X", name: "EUR/USD",     category: "forex",       price: 1.18,  previousClose: 1.17, change: 0.01, changePercent: 1.06, high: 1.19, low: 1.17, timestamp: new Date() },
+    { symbol: "GBPUSD=X", name: "GBP/USD",     category: "forex",       price: 1.35,  previousClose: 1.34, change: 0.01, changePercent: 1.20, high: 1.36, low: 1.34, timestamp: new Date() },
+    { symbol: "NQ=F",     name: "NASDAQ 100",  category: "indices",     price: 25000, previousClose: 24000, change: 1000, changePercent: 5.30, high: 25200, low: 24000, timestamp: new Date() },
+    { symbol: "ES=F",     name: "S&P 500",     category: "indices",     price: 5500,  previousClose: 5300, change: 200,  changePercent: 3.77, high: 5520, low: 5300, timestamp: new Date() },
+    { symbol: "BTC-USD",  name: "Bitcoin",     category: "crypto",      price: 74000, previousClose: 73000, change: 1000, changePercent: 1.37, high: 75000, low: 73000, timestamp: new Date() },
+    { symbol: "ETH-USD",  name: "Ethereum",    category: "crypto",      price: 3000,  previousClose: 2950, change: 50,   changePercent: 1.69, high: 3050, low: 2950, timestamp: new Date() },
+    { symbol: "GC=F",     name: "Gold",        category: "commodities", price: 3300,  previousClose: 3250, change: 50,   changePercent: 1.54, high: 3310, low: 3250, timestamp: new Date() },
+    { symbol: "CL=F",     name: "Crude Oil",   category: "commodities", price: 90,    previousClose: 95,   change: -5,   changePercent: -5.26, high: 95, low: 89, timestamp: new Date() },
+  ];
+
+  const fullAnalysis = [
+    "EUR/USD breaking above 1.18 resistance.",
+    "GBP/USD at 1.35 session high.",
+    "NASDAQ 100 surged +5% above 25000.",
+    "S&P 500 at session highs near 5500.",
+    "Bitcoin holding above 74000 support.",
+    "Ethereum showing strength at 3000.",
+    "Gold at 3300 resistance after rally.",
+    "Crude Oil crashed to 90 support on supply shock.",
+  ].join(" ");
+
+  it("warns when confidence >55 and analysis omits required instruments", () => {
+    const analysis = "EUR/USD and NASDAQ surged. Bitcoin holding support. Gold rallied.";
+    // Missing: GBP/USD, S&P, Ethereum, Crude Oil
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: analysis.padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 60,
+      setups: [], keyLevels: [], marketSnapshots: weekdaySnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(true);
+  });
+
+  it("does not warn when analysis mentions all 8 required instruments", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: fullAnalysis.padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 60,
+      setups: [], keyLevels: [], marketSnapshots: weekdaySnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(false);
+  });
+
+  it("does not warn when confidence is exactly 55 (threshold is >55)", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "EUR/USD only.".padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 55,
+      setups: [], keyLevels: [], marketSnapshots: weekdaySnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(false);
+  });
+
+  it("does not fire on weekend-style sessions with only 2 crypto snapshots", () => {
+    const cryptoOnlySnaps = [
+      { symbol: "BTC-USD", name: "Bitcoin",  category: "crypto", price: 74000, previousClose: 73000, change: 1000, changePercent: 1.37, high: 75000, low: 73000, timestamp: new Date() },
+      { symbol: "ETH-USD", name: "Ethereum", category: "crypto", price: 3000,  previousClose: 2950, change: 50,   changePercent: 1.69, high: 3050, low: 2950, timestamp: new Date() },
+    ];
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "Bitcoin and Ethereum showing strength today.".padEnd(300, " "),
+      bias: { overall: "bullish", notes: "crypto strength" }, confidence: 60,
+      setups: [], keyLevels: [], marketSnapshots: cryptoOnlySnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **#13 (Critical)** — Replaces hardcoded `Math.min(confidence, 45)` setup-count penalty with `applySetupCountPenalty()`: proportional −10pts per missing setup, floor 35%. Threshold changed from `>60% needs 4` to `>70% needs 4`, so sessions at 61-70% confidence with 3 setups (sessions #166-167 pattern) are no longer incorrectly penalized to 45%.
- **#14** — r031 cap enforcement: warns in `validateOracleOutput` when `effectiveConfidence > 65` without "capped from X%" notation in analysis text.
- **#15** — r036 DXY-weakness enforcement: warns when EUR/USD and GBP/USD both show `changePercent > 1%` and any setup is bearish on a risk asset (indices or crypto).
- **#16** — r041 pre-commitment enforcement: warns when `confidence > 55%` and analysis omits any of the 8 mandatory instruments (EUR/USD, GBP/USD, NASDAQ, S&P, BTC, ETH, Gold, Oil); skips weekend-style sessions with <4 instruments in snapshots.
- **#6 (partial)** — Extends `VIOLATION_KEYWORDS` with `"remains a known gap"`, `"known gap"`, `"requires enforcement"` patterns that sessions #166-167 used to acknowledge gaps without action.
- **axiom.ts** — Renames CONFIDENCE CALIBRATION NOTICE → CONFIDENCE ADJUSTMENT NOTICE and correctly explains setup-count enforcement and zero-setup contradiction as reasons for adjustment. Prevents AXIOM from diagnosing pipeline enforcement as "output mechanism corruption" (root cause of unnecessary r042).

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm test` — 498/498 tests pass (46 new tests added)
- [x] `applySetupCountPenalty(67, 3, false)` returns 67 (not 45) — regression for sessions #166-167
- [x] r031 warns on confidence 67 without cap notation
- [x] r036 warns on bearish NASDAQ during EUR/USD +1.06%, GBP/USD +1.20%
- [x] r041 warns when GBP/USD, S&P, Ethereum, Oil absent from analysis at 60% confidence
- [x] Extended rumination keywords catch "remains a known gap" pattern