### PR TITLE
fix(validate,agent): filterR036Setups — hard-remove bearish risk asset setups during DXY weakness

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -26,7 +26,7 @@ import {
   loadAllJournalEntries,
   saveJournalEntry,
 } from "./journal";
-import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, logFailure, loadRecentFailures, resolveConfidence } from "./validate";
+import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, logFailure, loadRecentFailures, resolveConfidence } from "./validate";
 import { buildAnalyticsSummary }                                    from "./analytics";
 import { fetchRSSNews, formatRSSForPrompt }                          from "./rss";
 import { notifySessionComplete }                                     from "./notifications";
@@ -534,6 +534,15 @@ export async function runAndValidateOracle(
       console.warn(`  ⚠ r029: removed setup [${r.instrument}] — ${r.reason}`);
     }
     oracle = filteredOracle;
+  }
+
+  // Filter bearish risk asset setups that violate r036 (DXY weakness confirmation)
+  const { oracle: r036FilteredOracle, removed: r036RemovedSetups } = filterR036Setups(oracle);
+  if (r036RemovedSetups.length > 0) {
+    for (const r of r036RemovedSetups) {
+      console.warn(`  ⚠ r036: removed setup [${r.instrument}] — ${r.reason}`);
+    }
+    oracle = r036FilteredOracle;
   }
 
   // Resolve confidence discrepancy: if the analysis text states a higher confidence than

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -636,6 +636,54 @@ export function filterNonCompliantSetups(oracle: OracleAnalysis): {
   };
 }
 
+// ── r036 Setup Filter ────────────────────────────────────
+// Hard-removes bearish risk asset setups when active DXY weakness is detected.
+// DXY weakness = EUR/USD and GBP/USD both up >1% in the same session.
+// Risk assets = indices and crypto (forex and commodities are not filtered).
+// Mirrors filterNonCompliantSetups pattern: returns new oracle + removal log.
+
+export function filterR036Setups(oracle: OracleAnalysis): {
+  oracle: OracleAnalysis;
+  removed: SetupRemovalRecord[];
+} {
+  const snapshots = oracle.marketSnapshots ?? [];
+
+  const eurUp = snapshots.some(s => {
+    const n = (s.name ?? "").toLowerCase();
+    const sym = (s.symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
+    return (n.includes("eur") || sym.includes("eurusd")) && (s.changePercent ?? 0) > 1;
+  });
+  const gbpUp = snapshots.some(s => {
+    const n = (s.name ?? "").toLowerCase();
+    const sym = (s.symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
+    return (n.includes("gbp") || sym.includes("gbpusd")) && (s.changePercent ?? 0) > 1;
+  });
+
+  if (!eurUp || !gbpUp) {
+    return { oracle, removed: [] };
+  }
+
+  const removed: SetupRemovalRecord[] = [];
+  const compliantSetups: typeof oracle.setups = [];
+
+  for (const s of oracle.setups) {
+    const cls = classifyInstrument(s.instrument ?? "", s.instrument ?? "");
+    if (s.direction === "bearish" && (cls === "indices" || cls === "crypto")) {
+      removed.push({
+        instrument: s.instrument ?? "unknown",
+        reason: `r036: bearish ${cls} setup removed — active DXY weakness (EUR/USD and GBP/USD both >+1%)`,
+      });
+    } else {
+      compliantSetups.push(s);
+    }
+  }
+
+  return {
+    oracle: { ...oracle, setups: compliantSetups },
+    removed,
+  };
+}
+
 // ── AXIOM Rumination Detector ─────────────────────────────
 // Detects when AXIOM acknowledges a compliance failure in text but
 // takes zero concrete action (no rule update, new rule, or self-task).

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, detectAxiomRumination, applySetupCountPenalty } from "../src/validate";
+import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, detectAxiomRumination, applySetupCountPenalty } from "../src/validate";
 import type { OracleAnalysis, JournalEntry } from "../src/types";
 
 // ── calculateTextSimilarity ─────────────────────────────────
@@ -1194,6 +1194,134 @@ describe("filterNonCompliantSetups", () => {
     } as any]);
     const { removed } = filterNonCompliantSetups(bearishOracle);
     expect(removed).toHaveLength(1);
+  });
+});
+
+// ── filterR036Setups ─────────────────────────────────────────
+
+describe("filterR036Setups", () => {
+  function makeSnap(name: string, symbol: string, changePercent: number) {
+    return {
+      symbol, name, category: "forex" as const,
+      price: 1.1, previousClose: 1.1 / (1 + changePercent / 100),
+      change: 1.1 * changePercent / 100, changePercent,
+      high: 1.11, low: 1.09, timestamp: new Date(),
+    };
+  }
+
+  function makeSetup(instrument: string, direction: "bullish" | "bearish", entry = 25000) {
+    const isBearish = direction === "bearish";
+    return {
+      instrument, type: "MSS" as const, direction,
+      description: "test", invalidation: "test",
+      entry,
+      stop: isBearish ? entry * 1.02 : entry * 0.98,
+      target: isBearish ? entry * 0.96 : entry * 1.04,
+      RR: 2, timeframe: "4H",
+    };
+  }
+
+  function makeOracle(snaps: any[], setups: any[]): OracleAnalysis {
+    return {
+      timestamp: new Date(), sessionId: "test", marketSnapshots: snaps,
+      analysis: "A".repeat(300), setups,
+      bias: { overall: "bullish", notes: "USD weakness" }, keyLevels: [], confidence: 55,
+    };
+  }
+
+  const eurUp   = makeSnap("EUR/USD", "EURUSD", 1.25);
+  const gbpUp   = makeSnap("GBP/USD", "GBPUSD", 1.34);
+  const eurFlat = makeSnap("EUR/USD", "EURUSD", 0.5);
+  const gbpFlat = makeSnap("GBP/USD", "GBPUSD", 0.3);
+
+  it("removes bearish index setup when EUR/USD and GBP/USD both >+1%", () => {
+    const oracle = makeOracle([eurUp, gbpUp], [makeSetup("NASDAQ 100", "bearish")]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(0);
+    expect(removed).toHaveLength(1);
+    expect(removed[0].instrument).toBe("NASDAQ 100");
+    expect(removed[0].reason).toMatch(/r036/);
+  });
+
+  it("removes bearish crypto setup when EUR/USD and GBP/USD both >+1%", () => {
+    const oracle = makeOracle([eurUp, gbpUp], [makeSetup("Bitcoin", "bearish", 80000)]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(0);
+    expect(removed).toHaveLength(1);
+    expect(removed[0].instrument).toBe("Bitcoin");
+  });
+
+  it("keeps bullish index/crypto setups even when EUR/USD and GBP/USD both >+1%", () => {
+    const oracle = makeOracle([eurUp, gbpUp], [makeSetup("NASDAQ 100", "bullish")]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("keeps bearish forex setups — r036 only blocks risk assets", () => {
+    const oracle = makeOracle([eurUp, gbpUp], [makeSetup("USD/JPY", "bearish", 150)]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("keeps bearish commodity setups — r036 only blocks risk assets", () => {
+    const oracle = makeOracle([eurUp, gbpUp], [makeSetup("Gold", "bearish", 3000)]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("does not filter when only EUR/USD is >+1% (GBP flat)", () => {
+    const oracle = makeOracle([eurUp, gbpFlat], [makeSetup("NASDAQ 100", "bearish")]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("does not filter when only GBP/USD is >+1% (EUR flat)", () => {
+    const oracle = makeOracle([eurFlat, gbpUp], [makeSetup("NASDAQ 100", "bearish")]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("does not filter when neither EUR/USD nor GBP/USD is >+1%", () => {
+    const oracle = makeOracle([eurFlat, gbpFlat], [makeSetup("NASDAQ 100", "bearish")]);
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("removes only violating setups in a mixed list", () => {
+    const oracle = makeOracle(
+      [eurUp, gbpUp],
+      [
+        makeSetup("NASDAQ 100", "bearish"),   // violates r036
+        makeSetup("EUR/USD", "bullish", 1.1), // OK — bullish
+        makeSetup("Bitcoin", "bearish", 80000), // violates r036
+      ]
+    );
+    const { oracle: filtered, removed } = filterR036Setups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect((filtered.setups as any)[0].instrument).toBe("EUR/USD");
+    expect(removed).toHaveLength(2);
+  });
+
+  it("does not mutate the original oracle object", () => {
+    const oracle = makeOracle([eurUp, gbpUp], [makeSetup("NASDAQ 100", "bearish")]);
+    filterR036Setups(oracle);
+    expect(oracle.setups).toHaveLength(1); // original unchanged
+  });
+
+  it("returns empty removed array when no setups present", () => {
+    const { removed } = filterR036Setups(makeOracle([eurUp, gbpUp], []));
+    expect(removed).toHaveLength(0);
+  });
+
+  it("returns empty removed array when no market snapshots present", () => {
+    const { removed } = filterR036Setups(makeOracle([], [makeSetup("NASDAQ 100", "bearish")]));
+    expect(removed).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Backlog item **#18**: r036 previously only warned when bearish index/crypto setups appeared during active DXY weakness (EUR/USD and GBP/USD both >+1%). Session #168 showed a bearish NASDAQ setup reaching the journal despite the warning firing.
- Add `filterR036Setups()` to `validate.ts` mirroring the `filterNonCompliantSetups` pattern — returns `{ oracle, removed }`, hard-removes bearish indices/crypto setups when EUR/USD and GBP/USD both show `changePercent > 1%` in `marketSnapshots`
- Forex and commodity setups are unaffected (r036 targets risk assets only)
- Wired into `agent.ts` immediately after the r029 filter

## Test plan

- [ ] 12 new tests in `filterR036Setups` describe block — all passing (510/510 total)
- [ ] Covers: bearish index removed, bearish crypto removed, bullish kept, forex bearish kept, commodity bearish kept, partial DXY weakness (one pair only) → no-op, neither pair → no-op, mixed list partial removal, no-mutation, empty setups edge case, empty snapshots edge case
- [ ] `tsc --noEmit` clean