### PR TITLE
fix(validate): enforce r041 'Screening validation:' template format

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -506,7 +506,9 @@ export function validateOracleOutput(
     }
   }
 
-  // r041: when confidence >55%, analysis must mention all 8 mandatory screening instruments.
+  // r041: when confidence >55%, analysis must use the explicit screening validation template.
+  // Required format: "Screening validation: EUR/USD [price] [level], GBP/USD [price] [level], ..."
+  // Instrument-mention checks are insufficient — the template format itself is the enforcement gate.
   // Only fires on weekday sessions (detected by ≥4 of the 8 instruments in marketSnapshots).
   if (effectiveConfidence > 55) {
     const snapNames = new Set(
@@ -515,28 +517,26 @@ export function validateOracleOutput(
         (s.symbol ?? "").toLowerCase().replace(/[^a-z]/g, ""),
       ])
     );
-    const r041Pairs: [string, string[]][] = [
-      ["EUR/USD",   ["eur/usd", "eurusd", "eur"]],
-      ["GBP/USD",   ["gbp/usd", "gbpusd", "gbp"]],
-      ["NASDAQ",    ["nasdaq", "nas100"]],
-      ["S&P",       ["s&p", "spx", "s&p500", "s&p 500"]],
-      ["BTC",       ["bitcoin", "btc"]],
-      ["ETH",       ["ethereum", "eth"]],
-      ["Gold",      ["gold", "xau"]],
-      ["Oil",       ["oil", "crude", "wti", "brent"]],
+    const r041Aliases: string[][] = [
+      ["eur/usd", "eurusd", "eur"],
+      ["gbp/usd", "gbpusd", "gbp"],
+      ["nasdaq", "nas100"],
+      ["s&p", "spx", "s&p500", "s&p 500"],
+      ["bitcoin", "btc"],
+      ["ethereum", "eth"],
+      ["gold", "xau"],
+      ["oil", "crude", "wti", "brent"],
     ];
-    // Only check pairs whose instruments are present in snapshots (weekday detection)
-    const presentPairs = r041Pairs.filter(([, aliases]) =>
+    const presentCount = r041Aliases.filter(aliases =>
       aliases.some(a => [...snapNames].some(n => n.includes(a.replace("/", ""))))
-    );
-    if (presentPairs.length >= 4) {
+    ).length;
+    if (presentCount >= 4) {
       const analysisLower = (oracle.analysis ?? "").toLowerCase();
-      const missing = presentPairs
-        .filter(([, aliases]) => !aliases.some(a => analysisLower.includes(a)))
-        .map(([name]) => name);
-      if (missing.length > 0) {
+      if (!analysisLower.includes("screening validation:")) {
         warnings.push(
-          `r041: ${effectiveConfidence}% confidence — pre-commitment screening requires mentioning all available instruments; missing from analysis: ${missing.join(", ")}`
+          `r041: ${effectiveConfidence}% confidence — analysis must include explicit screening validation template: ` +
+          `'Screening validation: EUR/USD [price] [level], GBP/USD [price] [level], NASDAQ [price] [level], ` +
+          `S&P [price] [level], BTC [price] [level], ETH [price] [level], Gold [price] [level], Oil [price] [level]'`
         );
       }
     }

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1742,10 +1742,31 @@ describe("validateOracleOutput r041 pre-commitment check", () => {
     expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(true);
   });
 
-  it("does not warn when analysis mentions all 8 required instruments", () => {
+  it("warns when all 8 instruments mentioned but 'Screening validation:' template absent", () => {
+    // fullAnalysis mentions all 8 instruments individually — old check would pass, new check must warn
     const oracle: OracleAnalysis = {
       sessionId: "test", timestamp: new Date(),
       analysis: fullAnalysis.padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 60,
+      setups: [], keyLevels: [], marketSnapshots: weekdaySnaps, assumptions: [],
+    };
+    expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(true);
+  });
+
+  it("does not warn when analysis contains 'Screening validation:' template with all 8 instruments", () => {
+    const templateAnalysis = [
+      "Screening validation: EUR/USD 1.18 resistance — viable long above 1.18.",
+      "GBP/USD 1.35 support — viable long on pullback.",
+      "NASDAQ 25000 resistance — no setup, extended.",
+      "S&P 5500 resistance — no setup, extended.",
+      "BTC 74000 support — viable long.",
+      "ETH 3000 support — no setup, low RR.",
+      "Gold 3300 resistance — viable long breakout.",
+      "Oil 90 support — no setup, conflicting bias.",
+    ].join(" ");
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: templateAnalysis.padEnd(300, " "),
       bias: { overall: "mixed", notes: "conflicting" }, confidence: 60,
       setups: [], keyLevels: [], marketSnapshots: weekdaySnaps, assumptions: [],
     };


### PR DESCRIPTION
## Summary
- r041 was updated in session #170 to require the explicit `Screening validation: EUR/USD [price] [level], ...` template format in the analysis text
- The previous `validateOracleOutput` check only verified that instrument names appeared anywhere in the analysis — ORACLE could satisfy it by mentioning EUR/USD in passing without a structured screening pass
- This PR replaces the instrument-mention scan with a simple template-prefix check: `"screening validation:"` must be present in the analysis text when confidence >55% on a weekday session

## Changes
- `src/validate.ts`: r041 block now checks for `"screening validation:"` prefix instead of per-instrument name aliases
- `tests/validate.test.ts`: added test proving instrument mentions alone no longer satisfy r041; added test confirming the template format passes

## Test plan
- [ ] `warns when all 8 instruments mentioned but 'Screening validation:' template absent` → asserts warn (new failing→passing test)
- [ ] `does not warn when analysis contains 'Screening validation:' template with all 8 instruments` → asserts no warn
- [ ] All 517 tests passing
- [ ] `tsc --noEmit` clean

Closes self-task #67.