### PR TITLE
fix(axiom): repair em-dash mojibake in analysis-rules.json and prevent recurrence

### DIFF
--- a/memory/analysis-rules.json
+++ b/memory/analysis-rules.json
@@ -27,7 +27,7 @@
     {
       "id": "r004",
       "category": "liquidity",
-      "description": "Equal highs/lows are liquidity targets â€” price is drawn to them before reversing",
+      "description": "Equal highs/lows are liquidity targets — price is drawn to them before reversing",
       "weight": 8,
       "addedSession": 0,
       "lastModifiedSession": 0
@@ -35,7 +35,7 @@
     {
       "id": "r005",
       "category": "correlation",
-      "description": "Check DXY direction when analyzing forex pairs â€” risk assets (indices, crypto) typically inversely correlate with DXY",
+      "description": "Check DXY direction when analyzing forex pairs — risk assets (indices, crypto) typically inversely correlate with DXY",
       "weight": 8,
       "addedSession": 0,
       "lastModifiedSession": 0
@@ -43,7 +43,7 @@
     {
       "id": "r006",
       "category": "sessions",
-      "description": "Asian range defines liquidity for London session â€” London often sweeps Asian highs or lows before the true move",
+      "description": "Asian range defines liquidity for London session — London often sweeps Asian highs or lows before the true move",
       "weight": 7,
       "addedSession": 0,
       "lastModifiedSession": 0
@@ -67,7 +67,7 @@
     {
       "id": "r009",
       "category": "crypto",
-      "description": "Bitcoin dominance matters â€” if BTC rises while altcoins fall, sentiment is defensive within crypto",
+      "description": "Bitcoin dominance matters — if BTC rises while altcoins fall, sentiment is defensive within crypto",
       "weight": 6,
       "addedSession": 0,
       "lastModifiedSession": 0
@@ -107,7 +107,7 @@
     {
       "id": "r014",
       "category": "confidence_methodology",
-      "description": "Confidence methodology: (1) Technical confluence: 1=20%, 2=35%, 3=45%, 4+=55%. (2) Macro alignment: 40-60% for strong correlation, 20-40% for weak correlation, 0-20% for breakdown. (3) RR clarity: +10% for RR>2.5, +5% for 1.5-2.5, -5% for <1.5. (4) Volatility adjustment: reduce by 10% during VIX>25. (5) Hard cap: maximum confidence 50% regardless of calculation. Analytics show 30-50% range well-calibrated (45% hit rate) while 50-70% range severely overconfident (21% hit rate). NOTE: displayed confidence is system-calibrated â€” do not modify this rule to compensate for calibration adjustments.",
+      "description": "Confidence methodology: (1) Technical confluence: 1=20%, 2=35%, 3=45%, 4+=55%. (2) Macro alignment: 40-60% for strong correlation, 20-40% for weak correlation, 0-20% for breakdown. (3) RR clarity: +10% for RR>2.5, +5% for 1.5-2.5, -5% for <1.5. (4) Volatility adjustment: reduce by 10% during VIX>25. (5) Hard cap: maximum confidence 50% regardless of calculation. Analytics show 30-50% range well-calibrated (45% hit rate) while 50-70% range severely overconfident (21% hit rate). NOTE: displayed confidence is system-calibrated — do not modify this rule to compensate for calibration adjustments.",
       "weight": 8,
       "addedSession": 2,
       "lastModifiedSession": 108
@@ -128,7 +128,7 @@
       "addedSession": 4,
       "lastModifiedSession": 7,
       "disabled": true,
-      "disabledReason": "Requires historical candle data (Phase 1 of roadmap) â€” re-enable when OHLCV data is available"
+      "disabledReason": "Requires historical candle data (Phase 1 of roadmap) — re-enable when OHLCV data is available"
     },
     {
       "id": "r017",
@@ -154,7 +154,7 @@
       "addedSession": 18,
       "lastModifiedSession": 18,
       "disabled": true,
-      "disabledReason": "Meta-rule that just references r012 â€” creates self-criticism loops without adding value"
+      "disabledReason": "Meta-rule that just references r012 — creates self-criticism loops without adding value"
     },
     {
       "id": "r020",
@@ -164,7 +164,7 @@
       "addedSession": 20,
       "lastModifiedSession": 20,
       "disabled": true,
-      "disabledReason": "Depends on r016 which requires historical candle data â€” re-enable when Phase 1 is implemented"
+      "disabledReason": "Depends on r016 which requires historical candle data — re-enable when Phase 1 is implemented"
     },
     {
       "id": "r021",

--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -18,6 +18,7 @@ import type {
   OracleAnalysis,
   AxiomReflection,
   AnalysisRules,
+  Rule,
   RuleUpdate,
   ForgeRequest,
 } from "./types";
@@ -570,6 +571,32 @@ function extractTopicWords(text: string): Set<string> {
   );
 }
 
+// ── Encoding sanitization ──────────────────────────────────────────────────
+
+// Repairs em-dash mojibake introduced by Windows-1252 misinterpretation of
+// UTF-8 em-dash bytes (E2 80 94 → â€" as 3 separate chars U+00E2 U+20AC U+201D).
+// Called before every writeFileSync on analysis-rules.json to prevent the
+// corruption from compounding across sessions.
+const MOJO_EM_DASH = "\u00e2\u20ac\u201d";
+const PROPER_EM_DASH = "\u2014";
+
+function fixMojibake(s: string): string {
+  return s.split(MOJO_EM_DASH).join(PROPER_EM_DASH);
+}
+
+export function sanitizeRulesText(rules: AnalysisRules): AnalysisRules {
+  return {
+    ...rules,
+    rules: rules.rules.map(r => {
+      const rule: any = { ...r, description: fixMojibake(r.description ?? "") };
+      if (typeof rule.disabledReason === "string") {
+        rule.disabledReason = fixMojibake(rule.disabledReason);
+      }
+      return rule as Rule;
+    }),
+  };
+}
+
 export function isThemeDuplicate(
   newText: string,
   existingSections: string[]
@@ -655,7 +682,7 @@ async function evolveMemory(
     updatedRules.sessionNotes= `Last updated: Session #${sessionNumber}`;
   }
 
-  fs.writeFileSync(ANALYSIS_RULES_PATH, JSON.stringify(updatedRules, null, 2));
+  fs.writeFileSync(ANALYSIS_RULES_PATH, JSON.stringify(sanitizeRulesText(updatedRules), null, 2), "utf-8");
 
   // ── Update system prompt (capped to prevent unbounded growth) ──
   let newSystemPrompt = currentSystemPrompt;

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { buildAxiomPrompt, parseAxiomResponse, handleSelfTasks, isThemeDuplicate } from "../src/axiom";
+import { buildAxiomPrompt, parseAxiomResponse, handleSelfTasks, isThemeDuplicate, sanitizeRulesText } from "../src/axiom";
 import type { OracleAnalysis, AnalysisRules } from "../src/types";
 
 function makeOracle(overrides: Partial<OracleAnalysis> = {}): OracleAnalysis {
@@ -405,5 +405,56 @@ describe("buildAxiomPrompt session type", () => {
     // Old 9-arg call still compiles and defaults to weekday
     const { userMessage } = buildAxiomPrompt(makeOracle(), 1, "", "", "", 0, "", makeRules(), "");
     expect(userMessage.toLowerCase()).toContain("weekday");
+  });
+});
+
+// ── sanitizeRulesText — encoding corruption repair ────────────
+
+describe("sanitizeRulesText", () => {
+  // The mojibake sequence: Windows-1252 bytes of em-dash (E2 80 94)
+  // decoded as individual chars U+00E2, U+20AC, U+201D → "â€""
+  const MOJO = "\u00e2\u20ac\u201d";
+  const EM   = "\u2014"; // proper em-dash —
+
+  function makeRulesWithMojo(): AnalysisRules {
+    return {
+      rules: [
+        { id: "r004", category: "liquidity", description: `Equal highs/lows are liquidity targets ${MOJO} price is drawn to them`, weight: 8, addedSession: 1, lastModifiedSession: 1 },
+        { id: "r016", category: "structure", description: "Normal rule no dash", weight: 5, addedSession: 1, lastModifiedSession: 1, disabled: true, disabledReason: `Requires candle data ${MOJO} re-enable later` },
+        { id: "r099", category: "misc",      description: "No corruption here",  weight: 5, addedSession: 1, lastModifiedSession: 1 },
+      ],
+      version: 5,
+      lastUpdated: "2026-04-15T00:00:00Z",
+      focusInstruments: [],
+      sessionNotes: "test",
+    } as any;
+  }
+
+  it("replaces mojibake em-dash sequence with proper em-dash in description", () => {
+    const result = sanitizeRulesText(makeRulesWithMojo());
+    const r004 = result.rules.find(r => r.id === "r004")!;
+    expect(r004.description).not.toContain(MOJO);
+    expect(r004.description).toContain(EM);
+  });
+
+  it("replaces mojibake in disabledReason field", () => {
+    const result = sanitizeRulesText(makeRulesWithMojo());
+    const r016 = result.rules.find(r => r.id === "r016")!;
+    expect((r016 as any).disabledReason).not.toContain(MOJO);
+    expect((r016 as any).disabledReason).toContain(EM);
+  });
+
+  it("leaves clean rules untouched", () => {
+    const result = sanitizeRulesText(makeRulesWithMojo());
+    const r099 = result.rules.find(r => r.id === "r099")!;
+    expect(r099.description).toBe("No corruption here");
+  });
+
+  it("handles multiple occurrences in one description", () => {
+    const rules = makeRulesWithMojo();
+    rules.rules[0].description = `A ${MOJO} B ${MOJO} C`;
+    const result = sanitizeRulesText(rules);
+    expect(result.rules[0].description).toBe(`A ${EM} B ${EM} C`);
+    expect(result.rules[0].description).not.toContain(MOJO);
   });
 });


### PR DESCRIPTION
## Summary
- 8 rule descriptions in `memory/analysis-rules.json` had corrupted em-dashes — the Windows-1252 byte sequence `â€"` (3 chars: U+00E2 U+20AC U+201D) instead of proper `—` (U+2014)
- Root cause: em-dash UTF-8 bytes were historically decoded as Windows-1252, stored as JSON escape sequences, then written back as literal mojibake bytes on the next round-trip
- The corruption was stable (not worsening per session) but wrong in all rule descriptions that use em-dashes

## Changes
- `src/axiom.ts`: added `sanitizeRulesText()` that replaces the mojibake 3-char sequence with `—` before every `writeFileSync`; added explicit `'utf-8'` encoding to the write call; exported for testing
- `tests/axiom.test.ts`: 4 new tests for `sanitizeRulesText` (description, disabledReason, clean rules, multiple occurrences)
- `memory/analysis-rules.json`: one-time byte-level repair of all 8 corrupted em-dashes (confirmed: 0 mojibake remaining, 8 proper em-dashes)

## Test plan
- [ ] `sanitizeRulesText` replaces mojibake in description → passes
- [ ] `sanitizeRulesText` replaces mojibake in disabledReason → passes
- [ ] Clean rules left untouched → passes
- [ ] Multiple occurrences in one description → passes
- [ ] All 521 tests passing
- [ ] `tsc --noEmit` clean

Closes backlog #22.