### PR TITLE
fix(validate): honor explicit cap notation in confidence extraction and r031 check

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -67,6 +67,13 @@ export function calculateTextSimilarity(text1: string, text2: string): number {
 // ── Confidence extraction from analysis text ─────────────
 
 export function extractConfidenceFromText(text: string): number | null {
+  // Pattern 0: explicit cap notation — ORACLE may calculate 70% but state "capped at 65%".
+  // Prefer the capped (final) value over the raw calculated value.
+  const capMatch = text.match(/capped\s+(?:at|to)\s*(\d+)%/i);
+  if (capMatch) {
+    return parseInt(capMatch[1], 10);
+  }
+
   // Pattern 1: "Confidence: X%" or "Confidence: X% —"
   const directMatch = text.match(/Confidence:\s*(\d+)%/i);
   if (directMatch) {
@@ -88,6 +95,16 @@ export function extractConfidenceFromText(text: string): number | null {
 // ── Confidence resolution ────────────────────────────────
 
 export function resolveConfidence(analysis: string, jsonConfidence: number): number {
+  // Honor explicit cap notation regardless of the 10-point threshold.
+  // When ORACLE says "capped at 65%" but returns 70 in JSON, the cap wins.
+  const capMatch = analysis.match(/capped\s+(?:at|to)\s*(\d+)%/i);
+  if (capMatch) {
+    const cappedValue = parseInt(capMatch[1], 10);
+    if (cappedValue < jsonConfidence) {
+      return cappedValue;
+    }
+  }
+
   const textConfidence = extractConfidenceFromText(analysis);
   if (textConfidence !== null && Math.abs(textConfidence - jsonConfidence) > 10) {
     return textConfidence;
@@ -470,12 +487,13 @@ export function validateOracleOutput(
     }
   }
 
-  // r031: confidence > 65% requires cap notation in analysis text
+  // r031: confidence > 65% requires cap notation in analysis text.
+  // Accepts "capped from X%", "capped at X%", or "capped to X%" — all valid forms.
   if (effectiveConfidence > 65) {
-    const hasCapNotation = /capped from \d+%/i.test(oracle.analysis ?? "");
+    const hasCapNotation = /capped\s+(?:from|at|to)\s*\d+%/i.test(oracle.analysis ?? "");
     if (!hasCapNotation) {
       warnings.push(
-        `r031: confidence ${effectiveConfidence}% exceeds 65% cap — analysis must include "capped from X% due to calibration discipline" notation per r031`
+        `r031: confidence ${effectiveConfidence}% exceeds 65% cap — analysis must include cap notation e.g. "capped from X%" or "capped at X%" per r031`
       );
     }
   }

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -711,6 +711,21 @@ describe("extractConfidenceFromText", () => {
   it("is case insensitive", () => {
     expect(extractConfidenceFromText("confidence: 55%")).toBe(55);
   });
+
+  it("returns capped value when 'capped at X%' notation is present", () => {
+    // ORACLE calculates 70% but caps to 65% — should return the capped value
+    const text = "Confidence: 70% — TC (80%), MA (70%), RR (60%). applying calibration discipline, capped at 65%.";
+    expect(extractConfidenceFromText(text)).toBe(65);
+  });
+
+  it("returns capped value when 'capped to X%' notation is present", () => {
+    const text = "Confidence: 72% — TC (75%), MA (70%), RR (70%). Capped to 65% per r031.";
+    expect(extractConfidenceFromText(text)).toBe(65);
+  });
+
+  it("still extracts direct value when no cap notation present", () => {
+    expect(extractConfidenceFromText("Confidence: 73% — TC (80%), MA (60%), RR (70%).")).toBe(73);
+  });
 });
 
 // ── Confidence mismatch validation ──────────────────────────
@@ -961,6 +976,18 @@ describe("resolveConfidence", () => {
   it("returns extracted value when mismatch is 11 points (just over boundary)", () => {
     const analysis = "Confidence: 71%";
     expect(resolveConfidence(analysis, 60)).toBe(71);
+  });
+
+  it("returns capped value when 'capped at X%' is explicit, even within 10-point threshold", () => {
+    // ORACLE says "Confidence: 70% ... capped at 65%" and JSON has 70.
+    // Diff = 5 (within threshold), but the cap is EXPLICIT — must honor it.
+    const analysis = "Confidence: 70% — TC (80%), MA (70%), RR (60%). applying calibration, capped at 65%.";
+    expect(resolveConfidence(analysis, 70)).toBe(65);
+  });
+
+  it("returns capped value when cap is below JSON confidence", () => {
+    const analysis = "Confidence: 72% — strong setup. Capped to 65% per calibration discipline.";
+    expect(resolveConfidence(analysis, 72)).toBe(65);
   });
 });
 
@@ -1600,9 +1627,26 @@ describe("validateOracleOutput r031 cap enforcement", () => {
     expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);
   });
 
-  it("does not warn when analysis contains cap notation", () => {
+  it("does not warn when analysis contains 'capped from X%' notation", () => {
     const result = validateOracleOutput(
       makeOracle31(67, "Confidence: 70% — TC (70%), MA (70%), RR (70%). capped from 72% due to calibration discipline."),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);
+  });
+
+  it("does not warn when analysis contains 'capped at X%' notation", () => {
+    // ORACLE writes "capped at 65%" — current regex misses this, must be fixed
+    const result = validateOracleOutput(
+      makeOracle31(67, "Confidence: 70% — TC (80%), MA (70%), RR (60%). applying calibration discipline, capped at 65%."),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);
+  });
+
+  it("does not warn when analysis contains 'Capped to X%' notation", () => {
+    const result = validateOracleOutput(
+      makeOracle31(67, "Confidence: 70% — TC (75%), MA (70%), RR (65%). Capped to 65% per r031."),
       []
     );
     expect(result.warnings.some((w) => w.includes("r031"))).toBe(false);


### PR DESCRIPTION
## Summary
- ORACLE can write "Confidence: 70%... capped at 65%" in its narrative but still return 70 in the JSON — the cap was being silently ignored
- The r031 regex only matched `"capped from X%"` and missed `"capped at X%"` and `"capped to X%"`, causing false warnings even when ORACLE correctly capped
- Together these bugs caused session #170 to show 70% confidence in the journal when the intended value (after cap + setup-count penalty) was 45%

## Changes
**`src/validate.ts`**
- `extractConfidenceFromText`: added Pattern 0 — checks for `"capped at/to X%"` before the `"Confidence: X%"` pattern; returns the capped value as the effective confidence
- `resolveConfidence`: added explicit cap check before the 10-point threshold — `"capped at 65%"` with JSON=70 was within threshold (diff=5) so was previously ignored; now returns 65
- r031 regex: extended from `/capped from \d+%/i` to `/capped\s+(?:from|at|to)\s*\d+%/i`

**`tests/validate.test.ts`**: 7 new tests (2 `extractConfidenceFromText`, 2 `resolveConfidence`, 3 r031)

## Behavioral change
When ORACLE caps at 65% and produces 1 setup on a weekday session:
- Before: `confidence = 70` (cap ignored, penalty on uncapped value)
- After: `confidence = 45` (cap honored → 65, then setup-count penalty of −20pts)

## Test plan
- [ ] `extractConfidenceFromText` returns capped value with "capped at/to" notation → passes
- [ ] `resolveConfidence` honors cap within 10-point threshold → passes
- [ ] r031 does not warn for "capped at/to X%" → passes
- [ ] All 528 tests passing
- [ ] `tsc --noEmit` clean

Closes backlog #23.