### PR TITLE
fix(axiom): normalize topic words to 5-char stems to catch morphological paraphrase variants

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -557,9 +557,23 @@ export async function runAxiomReflection(
 // This extends it with a topic-keyword check to catch the same
 // theme expressed in different words across multiple sessions
 // (e.g. "resist narrative dominance" appearing 5 sessions in a row).
+//
+// Words are normalized to their 5-character prefix before comparison so
+// morphological variants converge: execution/executing/executed → "execu",
+// generate/generation/generating → "gener", analysis/analytical → "analy".
+//
+// DOMAIN_STOP_STEMS filters out 5-char stems that appear in virtually every
+// section regardless of theme, preventing incidental overlap from triggering
+// false-positive duplicate detection.
 
-const DOMAIN_STOP_WORDS = new Set([
-  "market", "markets", "session", "sessions",
+const DOMAIN_STOP_STEMS = new Set([
+  "marke", // market / markets
+  "sessi", // session / sessions
+  "analy", // analysis / analytical / analyzing
+  "syste", // systematic / system
+  "requi", // require / requires / required
+  "acros", // across (transitional — appears in most sections)
+  "actio", // action / actions / actionable (too generic across themes)
 ]);
 
 function extractTopicWords(text: string): Set<string> {
@@ -567,7 +581,9 @@ function extractTopicWords(text: string): Set<string> {
     text.toLowerCase()
       .split(/\s+/)
       .map(w => w.replace(/[^a-z]/g, ""))
-      .filter(w => w.length >= 6 && !DOMAIN_STOP_WORDS.has(w))
+      .filter(w => w.length >= 6)
+      .map(w => w.slice(0, 5))
+      .filter(stem => !DOMAIN_STOP_STEMS.has(stem))
   );
 }
 

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -298,6 +298,49 @@ describe("isThemeDuplicate", () => {
     const result = isThemeDuplicate(weekendSection, [narrativeSection134, narrativeSection135]);
     expect(result.isDuplicate).toBe(false);
   });
+
+  // ── Morphological variant tests (backlog #7) ──────────────
+  // These are the cases that slipped through: same theme, different word forms.
+  // "execution/setup generation failures" expressed across sessions using
+  // execute/executing/executed and generate/generating/generation etc.
+
+  const execGapSession1 =
+    "When systematic execution failures occur across multiple asset classes, " +
+    "document the analytical gap and generate actionable setups rather than " +
+    "simply noting the price action. Execution discipline requires converting " +
+    "observations into structured trade plans.";
+
+  const execGapSession2 =
+    "Systematic analysis of coordinated market moves must generate executable " +
+    "setups. Analytical observations without actionable structures indicate an " +
+    "execution gap — market intelligence requires conversion of insights into " +
+    "specific entry, stop, and target levels.";
+
+  const execGapSession3 =
+    "Setup generation failures during high-conviction sessions indicate executing " +
+    "discipline gaps. Converting analytical observations into structured setups is " +
+    "non-negotiable — generated intelligence without corresponding trade structures " +
+    "represents incomplete analysis regardless of narrative quality.";
+
+  it("detects morphological variants of execution/setup theme (session1 vs session2)", () => {
+    const result = isThemeDuplicate(execGapSession2, [execGapSession1]);
+    expect(result.isDuplicate).toBe(true);
+  });
+
+  it("detects morphological variants of execution/setup theme (session3 vs session1)", () => {
+    const result = isThemeDuplicate(execGapSession3, [execGapSession1]);
+    expect(result.isDuplicate).toBe(true);
+  });
+
+  it("does not flag execution-gap theme against narrative-dominance theme", () => {
+    const result = isThemeDuplicate(execGapSession1, [narrativeSection134, narrativeSection135]);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  it("does not flag oil-volatility theme against execution-gap theme", () => {
+    const result = isThemeDuplicate(oilSection, [execGapSession1, execGapSession2]);
+    expect(result.isDuplicate).toBe(false);
+  });
 });
 
 // ── handleSelfTasks ───────────────────────────────────────


### PR DESCRIPTION
## Problem

Backlog #7: near-duplicate system prompt additions slipping through dedup.

The topic-keyword check in `isThemeDuplicate` used **exact word matching**, so morphological variants of the same theme registered as different words:

| Theme | Session A words | Session B words |
|-------|-----------|-----------|
| Execution gap | `execution`, `generate`, `analytical` | `executing`, `generation`, `analysis` |

These share zero exact topic words despite being semantically identical, so the dedup threshold (`sharedCount >= 3`) was never reached.

A second bug was also found: the existing code produced **false positives** — an execution-gap section was incorrectly flagged as a duplicate of a narrative-dominance section because generic domain words (`analytical`, `systematic`, `requires`, `across`, `action`) appeared in both.

## Fix

**`src/axiom.ts` — `extractTopicWords`**

1. **5-char prefix normalization**: each topic word is truncated to its first 5 characters before comparison, collapsing morphological variants:
   - `execution` / `executing` / `executed` → `execu`
   - `generation` / `generate` / `generating` → `gener`
   - `analysis` / `analytical` / `analyzing` → `analy`

2. **`DOMAIN_STOP_WORDS` → `DOMAIN_STOP_STEMS`**: switched from full-word to 5-char stem filtering, and expanded with stems that appear generically across all sections regardless of theme:
   - `analy` (analysis/analytical) — was causing false positives
   - `syste` (systematic/system) — was causing false positives
   - `requi` (require/requires) — was causing false positives
   - `acros` (across) — transitional, appears everywhere
   - `actio` (action/actions/actionable) — too ambiguous across themes

## Tests

Four new cases added to `tests/axiom.test.ts`:

| Test | Expected | Before | After |
|------|----------|--------|-------|
| execGapSession2 vs execGapSession1 (morphological variants) | duplicate | ✗ missed | ✓ caught |
| execGapSession3 vs execGapSession1 (morphological variants) | duplicate | ✗ missed | ✓ caught |
| execGap vs narrative-dominance (false positive guard) | not duplicate | ✗ false positive | ✓ correct |
| oil-volatility vs execGap (cross-theme guard) | not duplicate | ✓ correct | ✓ correct |

All 532 existing tests continue to pass.