### PR TITLE
fix(axiom): log soft warning when deferred gap lacks tracking self-task (backlog #6)

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -6,7 +6,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { createSelfTask, closeSelfTask, SelfTask } from "./self-tasks";
 import { sanitizeAxiomOutput, getMaxOutputTokens, getMaxSystemPromptLength } from "./security";
-import { validateAxiomOutput, logFailure, extractConfidenceFromText, calculateTextSimilarity, detectAxiomRumination } from "./validate";
+import { validateAxiomOutput, logFailure, extractConfidenceFromText, calculateTextSimilarity, detectAxiomRumination, detectAcknowledgedGap } from "./validate";
 import { loadAllJournalEntries } from "./journal";
 import {
   salvageJSON, stripSurrogates, extractJSONFromResponse,
@@ -407,6 +407,19 @@ export function parseAxiomResponse(
     newRules:     parsed.newRules,
     newSelfTasks: parsed.newSelfTasks,
   });
+  // Second half (backlog #6): log a soft warning when AXIOM uses explicit deferral
+  // language ("known gap", "requires enforcement") and modifies rules but omits a
+  // self-task — leaving the deferred gap untracked. Log-only; no forced injection.
+  const gapAcknowledgementWarning = detectAcknowledgedGap({
+    whatFailed:   rawParsed.whatFailed,
+    ruleUpdates:  parsed.ruleUpdates,
+    newRules:     parsed.newRules,
+    newSelfTasks: parsed.newSelfTasks,
+  });
+  if (gapAcknowledgementWarning) {
+    console.warn(`  ⚠ Axiom: ${gapAcknowledgementWarning}`);
+  }
+
   if (ruminationWarning) {
     const alreadyHasRuleGap = (parsed.newSelfTasks ?? []).some(
       (t: any) => t.category === "rule-gap"

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -738,6 +738,47 @@ export function detectAxiomRumination(parsed: {
   return "AXIOM acknowledged failure without action: compliance failure identified in whatFailed but no rule updates, new rules, or self-tasks were created — a forced self-task will be injected";
 }
 
+// ── Acknowledged Gap Detector (backlog #6 second half) ────
+// Fires when AXIOM uses explicit DEFERRAL language ("known gap",
+// "requires enforcement") — meaning AXIOM is aware of the gap but
+// is not fixing it this session — AND takes rule-change action
+// (so detectAxiomRumination's force-inject is bypassed) but omits
+// a self-task. Without a self-task, the deferred gap has no tracking
+// mechanism and will silently repeat every session.
+
+const DEFERRAL_KEYWORDS = [
+  "remains a known gap", "known gap", "requires enforcement",
+  "gap requiring enforcement", "requires code enforcement",
+  "enforcement rather than", "need enforcement mechanism",
+  "need validation logic",
+];
+
+export function detectAcknowledgedGap(parsed: {
+  whatFailed?: string;
+  ruleUpdates?: any[];
+  newRules?: any[];
+  newSelfTasks?: any[];
+}): string | null {
+  const failText = (parsed.whatFailed ?? "").toLowerCase();
+  if (!failText) return null;
+
+  const hasDeferralLanguage = DEFERRAL_KEYWORDS.some(kw => failText.includes(kw));
+  if (!hasDeferralLanguage) return null;
+
+  const hasRuleUpdate = (parsed.ruleUpdates ?? []).length > 0;
+  const hasNewRule    = (parsed.newRules     ?? []).length > 0;
+  const hasSelfTask   = (parsed.newSelfTasks ?? []).length > 0;
+
+  // No action at all — detectAxiomRumination already handles this with a forced injection.
+  if (!hasRuleUpdate && !hasNewRule && !hasSelfTask) return null;
+
+  // A self-task exists: the gap is explicitly tracked across sessions.
+  if (hasSelfTask) return null;
+
+  // Rule changes were made but no self-task created — the deferred gap goes untracked.
+  return "AXIOM explicitly deferred a gap ('known gap'/'requires enforcement') and modified rules without a self-task — the gap will remain untracked across sessions";
+}
+
 // ── Bias-to-Rule Mapping Checker ─────────────────────────
 // Detects when AXIOM identifies cognitive biases but produces no rule updates
 // that address them. Warns so the feedback reaches AXIOM's next context.
@@ -905,6 +946,10 @@ export function validateAxiomOutput(
   // Detect unacted compliance violations (rumination blind spot)
   const ruminationWarning = detectAxiomRumination(parsed);
   if (ruminationWarning) warnings.push(ruminationWarning);
+
+  // Detect explicitly deferred gaps that lack a tracking self-task (backlog #6 second half)
+  const gapWarning = detectAcknowledgedGap(parsed);
+  if (gapWarning) warnings.push(gapWarning);
 
   return {
     valid: errors.length === 0,

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, detectAxiomRumination, applySetupCountPenalty } from "../src/validate";
+import { calculateTextSimilarity, validateOracleOutput, validateAxiomOutput, extractConfidenceFromText, resolveConfidence, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, detectAxiomRumination, detectAcknowledgedGap, applySetupCountPenalty } from "../src/validate";
 import type { OracleAnalysis, JournalEntry } from "../src/types";
 
 // ── calculateTextSimilarity ─────────────────────────────────
@@ -1532,6 +1532,73 @@ describe("detectAxiomRumination — enforcement mechanism language", () => {
       whatFailed: "The screening gap remains a known gap requiring enforcement.",
       ruleUpdates: [], newRules: [],
       newSelfTasks: [{ title: "Fix screening enforcement", category: "rule-gap", priority: "high" }],
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ── detectAcknowledgedGap (backlog #6 second half) ────────────
+// Fires when AXIOM uses explicit deferral language ("known gap", "requires
+// enforcement") AND takes rule-change action, but omits a self-task —
+// meaning the gap gets deferred again with no tracking mechanism.
+
+describe("detectAcknowledgedGap", () => {
+  it("returns warning when deferral language + rule update + no self-task", () => {
+    const result = detectAcknowledgedGap({
+      whatFailed: "The screening accountability remains a known gap requiring enforcement.",
+      ruleUpdates: [{ ruleId: "r041", type: "modify", before: "old", after: "updated screening", reason: "improve weekend logic" }],
+      newRules: [],
+      newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("returns warning when 'requires enforcement' language + new rule + no self-task", () => {
+    const result = detectAcknowledgedGap({
+      whatFailed: "This gap requires code enforcement to be resolved systematically.",
+      ruleUpdates: [],
+      newRules: [{ id: "r045", description: "enforce new check", category: "execution", weight: 8 }],
+      newSelfTasks: [],
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null when self-task is present — gap is tracked", () => {
+    const result = detectAcknowledgedGap({
+      whatFailed: "The screening gap remains a known gap requiring enforcement.",
+      ruleUpdates: [{ ruleId: "r041", type: "modify", before: "old", after: "new", reason: "improve" }],
+      newRules: [],
+      newSelfTasks: [{ title: "Track known enforcement gap", category: "rule-gap", priority: "high" }],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no deferral language — generic compliance failure is handled by detectAxiomRumination", () => {
+    const result = detectAcknowledgedGap({
+      whatFailed: "Critical compliance failure on r029 — stop distances violated minimum requirements.",
+      ruleUpdates: [{ ruleId: "r029", type: "modify", before: "old", after: "wider stops", reason: "fix stops" }],
+      newRules: [],
+      newSelfTasks: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no action taken — detectAxiomRumination handles the zero-action case", () => {
+    const result = detectAcknowledgedGap({
+      whatFailed: "This remains a known gap requiring enforcement.",
+      ruleUpdates: [],
+      newRules: [],
+      newSelfTasks: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when whatFailed is empty", () => {
+    const result = detectAcknowledgedGap({
+      whatFailed: "",
+      ruleUpdates: [{ ruleId: "r041", type: "modify", before: "x", after: "y", reason: "z" }],
+      newRules: [],
+      newSelfTasks: [],
     });
     expect(result).toBeNull();
   });


### PR DESCRIPTION
## Problem

Backlog #6 (second half): when AXIOM uses explicit deferral language — `"known gap"`, `"requires enforcement"`, `"requires code enforcement"` — in `whatFailed` AND modifies rules (so the existing force-inject path is bypassed), but omits a self-task, the deferred gap has **no tracking mechanism**. It silently repeats every session with no visibility.

The first half (PR #63) added `VIOLATION_KEYWORDS` to catch zero-action violations and force-inject a self-task. That path only fires when `ruleUpdates`, `newRules`, and `newSelfTasks` are all empty. When rule changes ARE present alongside deferral language, nothing is logged at all.

## Fix

**New `detectAcknowledgedGap` function** (`src/validate.ts`):
- Uses a targeted `DEFERRAL_KEYWORDS` subset focused on explicit deferral patterns: `"known gap"`, `"remains a known gap"`, `"requires enforcement"`, `"requires code enforcement"`, `"gap requiring enforcement"`, `"need enforcement mechanism"`, `"need validation logic"`, `"enforcement rather than"`
- Returns `null` when: no deferral language, no action taken (already handled by `detectAxiomRumination`), or a self-task is present (gap is explicitly tracked)
- Returns a soft warning string only when: deferral language + rule changes + **no self-task**

**Wired up in two places:**
- `axiom.ts` `parseAxiomResponse`: `console.warn` (log-only, no forced injection — AXIOM did take action)
- `validate.ts` `validateAxiomOutput`: added to validation warnings array

## Tests

Six new cases in `tests/validate.test.ts`:

| Test | Expected |
|------|----------|
| Deferral language + rule update + no self-task | warning |
| Deferral language + new rule + no self-task | warning |
| Deferral language + rule update + self-task present | null (tracked) |
| Generic compliance failure without deferral language | null (detectAxiomRumination handles) |
| Deferral language + no action at all | null (detectAxiomRumination handles) |
| Empty whatFailed | null |

All 538 tests pass.