### PR TITLE
fix(session): harden concurrent conflict handler for analysis-rules and system-prompt

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -149,12 +149,35 @@ jobs:
             # analysis-rules.json: merge remote + local using the dedicated script.
             # Remote is taken as the base; local rule changes are applied on top
             # (new rules added, rules with higher lastModifiedSession win).
+            # Fallback: if the merge script fails or produces invalid JSON, restore
+            # the pre-conflict local version (saved above before the pull) which is
+            # always valid JSON and contains the current session's changes.
             if grep -ql "^<<<<<<" memory/analysis-rules.json 2>/dev/null; then
-              git show origin/main:memory/analysis-rules.json > /tmp/nexus-remote-rules.json 2>/dev/null
-              node scripts/merge-analysis-rules.js /tmp/nexus-remote-rules.json /tmp/nexus-local-rules.json > /tmp/nexus-merged-rules.json
-              cp /tmp/nexus-merged-rules.json memory/analysis-rules.json
-              echo "Merged analysis-rules.json (concurrent session conflict resolved)"
+              git show origin/main:memory/analysis-rules.json > /tmp/nexus-remote-rules.json 2>/dev/null || true
+              if node scripts/merge-analysis-rules.js /tmp/nexus-remote-rules.json /tmp/nexus-local-rules.json > /tmp/nexus-merged-rules.json 2>/dev/null \
+                 && node -e "JSON.parse(require('fs').readFileSync('/tmp/nexus-merged-rules.json','utf8'))" 2>/dev/null; then
+                cp /tmp/nexus-merged-rules.json memory/analysis-rules.json
+                echo "Merged analysis-rules.json (concurrent session conflict resolved)"
+              else
+                cp /tmp/nexus-local-rules.json memory/analysis-rules.json
+                echo "Merge script failed — restored local analysis-rules.json as fallback"
+              fi
               git add memory/analysis-rules.json
+            fi
+
+            # memory/system-prompt.md: both sessions appended a new evolved section.
+            # Keep content from both halves by stripping git conflict markers.
+            # This preserves both sessions' analytical insights in the prompt history.
+            if grep -ql "^<<<<<<" memory/system-prompt.md 2>/dev/null; then
+              grep -v "^<<<<<<<\|^=======\|^>>>>>>>" memory/system-prompt.md > /tmp/nexus-merged-prompt.md || true
+              if [ -s /tmp/nexus-merged-prompt.md ]; then
+                cp /tmp/nexus-merged-prompt.md memory/system-prompt.md
+                echo "Merged system-prompt.md (kept both evolved sections)"
+              else
+                git checkout --ours memory/system-prompt.md 2>/dev/null || true
+                echo "system-prompt.md merge fallback — took ours"
+              fi
+              git add memory/system-prompt.md
             fi
 
             # docs/index.html: take theirs — we always rebuild it below anyway

--- a/tests/merge-analysis-rules.test.ts
+++ b/tests/merge-analysis-rules.test.ts
@@ -120,4 +120,44 @@ describe("mergeAnalysisRules", () => {
     const merged = mergeAnalysisRules(remote, local);
     expect(() => JSON.parse(JSON.stringify(merged))).not.toThrow();
   });
+
+  // ── Edge-case robustness (backlog #5) ────────────────────
+  // These document guarantees needed for the concurrent-session conflict handler.
+
+  it("preserves disabled and disabledReason fields when local rule wins by lastModifiedSession", () => {
+    const remote = {
+      rules: [{ ...baseRule("r016", 0), disabled: false }],
+      version: 10, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "", focusInstruments: [],
+    };
+    const local = {
+      rules: [{ ...baseRule("r016", 170), disabled: true, disabledReason: "replaced by code enforcement" }],
+      version: 11, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "", focusInstruments: [],
+    };
+    const merged = mergeAnalysisRules(remote, local);
+    const r = merged.rules.find((x: any) => x.id === "r016");
+    expect(r.disabled).toBe(true);
+    expect(r.disabledReason).toBe("replaced by code enforcement");
+  });
+
+  it("falls back to remote sessionNotes when local higherVersion has undefined sessionNotes", () => {
+    const remote = { rules: [], version: 10, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "Remote notes", focusInstruments: [] };
+    const local  = { rules: [], version: 10, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: undefined as any, focusInstruments: [] };
+    // Same version → local wins higherVersion check; its sessionNotes is undefined → falls back to remote's
+    const merged = mergeAnalysisRules(remote, local);
+    expect(merged.sessionNotes).toBe("Remote notes");
+  });
+
+  it("handles missing lastUpdated in remote by taking local timestamp", () => {
+    const remote = { rules: [], version: 10, lastUpdated: undefined as any, sessionNotes: "", focusInstruments: [] };
+    const local  = { rules: [], version: 11, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "", focusInstruments: [] };
+    expect(mergeAnalysisRules(remote, local).lastUpdated).toBe("2026-04-11T13:08:00.000Z");
+  });
+
+  it("handles missing focusInstruments in local higherVersion by falling back to remote", () => {
+    const remote = { rules: [], version: 10, lastUpdated: "2026-04-11T13:07:00.000Z", sessionNotes: "", focusInstruments: ["BTC", "ETH"] };
+    const local  = { rules: [], version: 10, lastUpdated: "2026-04-11T13:08:00.000Z", sessionNotes: "", focusInstruments: undefined as any };
+    // Same version → local is higherVersion; its focusInstruments is undefined → falls back to remote
+    const merged = mergeAnalysisRules(remote, local);
+    expect(merged.focusInstruments).toEqual(["BTC", "ETH"]);
+  });
 });


### PR DESCRIPTION
## Summary

- **Error guard on merge script**: `merge-analysis-rules.js` invocation now validates the output is valid JSON before applying it. On script failure or invalid output, falls back to the pre-saved local `analysis-rules.json` (captured before the `git pull --rebase`), which is always valid. Previously, a script failure would leave `analysis-rules.json` in a broken state.
- **`system-prompt.md` conflict handler**: When two concurrent sessions both append an evolved section, the autostash pop creates conflict markers in `memory/system-prompt.md`. The new handler strips conflict markers and retains both sessions' content. Falls back to `--ours` if the result is empty.
- **4 documenting tests**: Added to `tests/merge-analysis-rules.test.ts` to lock in guarantees for the merge script's edge-case behavior (disabled/disabledReason preservation, missing lastUpdated, undefined sessionNotes fallback, missing focusInstruments fallback).

Closes backlog #5 — the last open backlog item from the concurrent session conflict handler work.

## Test plan
- [x] `npm test` — 542 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] New tests cover all documented edge cases in the merge script