### PR TITLE
fix(oracle): inject r041 screening validation requirement into ORACLE-ANALYSIS prompt

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -153,6 +153,8 @@ Skipping any instrument on this list is a rule violation (r030).
   const allEntries = loadAllJournalEntries();
   const calibrationContext = buildCalibrationContext(allEntries);
 
+  const r041Note = !isWeekend ? buildR041ScreeningNote() : "";
+
   const analysisUserMessage = `
 ${weekendContext}${marketData}
 
@@ -183,7 +185,7 @@ FORMAT REQUIREMENTS:
    or correlation breakdown. Otherwise pick a direction (per r015).
 
 4. KEY LEVELS: Identify important support/resistance levels across all instruments.
-
+${r041Note}
 5. ASSUMPTIONS (r011 \u2014 MANDATORY): List every causal attribution to an unverified external event
    in the "assumptions" array. This includes geopolitical events, central bank actions, earnings,
    or any "X caused Y" claim not confirmed by price data alone.
@@ -633,6 +635,24 @@ export function buildMinSetupNote(confidence: number): string {
   if (confidence < 50) return "";
   const minSetups = confidence >= 60 ? 4 : 3;
   return `\nMANDATORY SETUP COUNT (your confidence is ${confidence}%): You MUST provide at least ${minSetups} setups. Returning fewer is a rule violation (r034). Systematically screen ALL instruments — forex majors, indices, crypto, commodities — before concluding no setup exists.\n`;
+}
+
+// ── r041 screening validation enforcement ─────────────────
+// Returns a prompt block requiring ORACLE to include a "Screening validation:"
+// line in its analysis text when confidence exceeds 55% on weekday sessions.
+// Injected into ORACLE-ANALYSIS prompt (pre-construction) so the requirement
+// is active before setup generation begins — not post-hoc like validateOracleOutput.
+// Root cause of sessions #168-#172: ORACLE omitted the mandatory prefix despite
+// having the analytical information to produce it.
+export function buildR041ScreeningNote(): string {
+  return `
+5. SCREENING VALIDATION (r041 — MANDATORY when your confidence exceeds 55%):
+   At the end of your Technical Confluence Analysis section, add a line in EXACTLY this format:
+   "Screening validation: EUR/USD [price] [level], GBP/USD [price] [level], NASDAQ [price] [level], S&P [price] [level], BTC [price] [level], ETH [price] [level], Gold [price] [level], Oil [price] [level]"
+   Replace [price] with the current instrument price and [level] with the key support/resistance level you identified.
+   If your confidence is ≤55%, you may omit this line.
+   This line is required BEFORE you proceed to any other content.
+`;
 }
 
 // ── RR self-check enforcement ──────────────────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote, buildWeekdayScreeningTemplate } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote } from "../src/oracle";
 import type { MarketSnapshot } from "../src/types";
 
 function makeSnap(changePercent: number): MarketSnapshot {
@@ -1066,5 +1066,39 @@ describe("buildWeekdayScreeningTemplate", () => {
 
   it("returns empty string for empty snapshots regardless of confidence", () => {
     expect(buildWeekdayScreeningTemplate([], 80)).toBe("");
+  });
+});
+
+// ── buildR041ScreeningNote ────────────────────────────────
+
+describe("buildR041ScreeningNote", () => {
+  it("returns a non-empty string", () => {
+    expect(buildR041ScreeningNote()).toBeTruthy();
+  });
+
+  it("contains the 'Screening validation:' format requirement", () => {
+    expect(buildR041ScreeningNote()).toContain("Screening validation:");
+  });
+
+  it("references the 55% confidence threshold", () => {
+    expect(buildR041ScreeningNote()).toContain("55%");
+  });
+
+  it("lists all 8 required r041 instruments", () => {
+    const note = buildR041ScreeningNote();
+    expect(note).toContain("EUR/USD");
+    expect(note).toContain("GBP/USD");
+    expect(note).toContain("NASDAQ");
+    expect(note).toContain("S&P");
+    expect(note).toContain("BTC");
+    expect(note).toContain("ETH");
+    expect(note).toContain("Gold");
+    expect(note).toContain("Oil");
+  });
+
+  it("mentions price and level placeholders in the example format", () => {
+    const note = buildR041ScreeningNote();
+    expect(note).toMatch(/\[price\]/i);
+    expect(note).toMatch(/\[level\]/i);
   });
 });


### PR DESCRIPTION
## Problem

r041 requires ORACLE to include a `"Screening validation: EUR/USD [price] [level], ..."` line in its analysis text when confidence exceeds 55%. This failed for **5 consecutive sessions** (#168–#172). AXIOM correctly diagnosed the gap each time but took no action — classic rumination. Self-task #67 (filed session #170) sat open for 3 sessions without resolution.

Root cause: the existing enforcement in `validateOracleOutput` (PR #63/PR #68) is **post-hoc** — it fires a warning after ORACLE has already produced its response. The warning is logged but has no effect on the model's output in the current session.

## Fix

Add `buildR041ScreeningNote()` and inject it into the **ORACLE-ANALYSIS prompt** as FORMAT REQUIREMENT #5 (weekday sessions only). This tells ORACLE to include the screening validation line **before** setup construction begins, mirroring the pattern used by `buildRRSelfCheckNote()` in PR #66.

```
5. SCREENING VALIDATION (r041 — MANDATORY when your confidence exceeds 55%):
   At the end of your Technical Confluence Analysis section, add a line in EXACTLY this format:
   "Screening validation: EUR/USD [price] [level], GBP/USD [price] [level], ..."
```

The `validateOracleOutput` post-hoc warning remains in place as a secondary guard.

## Test plan
- [x] `npm test` — 547 tests pass (5 new: `buildR041ScreeningNote` returns correct content, mentions 55% threshold, lists all 8 instruments, includes `[price]`/`[level]` placeholders)
- [x] `npx tsc --noEmit` — no type errors
- [x] Weekend sessions excluded (`r041Note = !isWeekend ? buildR041ScreeningNote() : ""`)