### PR TITLE
fix(oracle): extract computeOracleConfidence and remove agent.ts double-call bug

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -26,7 +26,7 @@ import {
   loadAllJournalEntries,
   saveJournalEntry,
 } from "./journal";
-import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, logFailure, loadRecentFailures, resolveConfidence } from "./validate";
+import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, logFailure, loadRecentFailures } from "./validate";
 import { buildAnalyticsSummary }                                    from "./analytics";
 import { fetchRSSNews, formatRSSForPrompt }                          from "./rss";
 import { notifySessionComplete }                                     from "./notifications";
@@ -545,14 +545,10 @@ export async function runAndValidateOracle(
     oracle = r036FilteredOracle;
   }
 
-  // Resolve confidence discrepancy: if the analysis text states a higher confidence than
-  // the JSON field, use the text value so the journal records the correct number.
-  // This corrects cases where ORACLE writes inconsistent values (e.g. session #163: JSON=45, text=61).
-  const resolvedConfidence = resolveConfidence(oracle.analysis, oracle.confidence);
-  if (resolvedConfidence !== oracle.confidence) {
-    console.log(chalk.dim(`  ↳ Confidence resolved: ${oracle.confidence}% → ${resolvedConfidence}% (text-extracted value)`));
-    oracle = { ...oracle, confidence: resolvedConfidence };
-  }
+  // Note: confidence is already resolved and penalized by computeOracleConfidence() inside
+  // runOracleAnalysis(). Do NOT call resolveConfidence() again here — it would silently undo
+  // any setup-count penalty by seeing diff > 10pts between analysis text and penalized value.
+  // See backlog #23 and computeOracleConfidence() in oracle.ts.
 
   // Print brief summary
   console.log("");

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -485,22 +485,15 @@ Only respond with the JSON array, no other text.`;
     }
   }
 
-  // Resolve text vs JSON confidence mismatch
-  let finalConfidence = resolveConfidence(parsed.analysis ?? "", parsed.confidence ?? 50);
-
-  // Enforce: high confidence with zero setups is contradictory
-  if (finalConfidence > 60 && validSetups.length === 0) {
-    console.warn(`  \u26a0 ORACLE contradiction: ${finalConfidence}% confidence but 0 setups \u2014 forcing confidence to 35%`);
-    finalConfidence = 35;
-  }
-
-  // Enforce minimum setup counts based on confidence (proportional penalty, backlog #13)
-  const { penalized: penalizedConfidence, reason: penaltyReason } =
-    applySetupCountPenalty(finalConfidence, validSetups.length, isWeekend);
-  if (penaltyReason) {
-    console.warn(`  \u26a0 ORACLE ${penaltyReason}`);
-    finalConfidence = penalizedConfidence;
-  }
+  // Compute final confidence: text/JSON reconciliation → zero-setup floor → setup-count penalty.
+  // Uses computeOracleConfidence so the pipeline is testable and agent.ts does not need to
+  // call resolveConfidence again (which would undo any penalty — backlog #23 double-call bug).
+  const finalConfidence = computeOracleConfidence(
+    parsed.analysis ?? "",
+    parsed.confidence ?? 50,
+    validSetups.length,
+    isWeekend
+  );
 
   return {
     timestamp:       new Date(),
@@ -635,6 +628,32 @@ export function buildMinSetupNote(confidence: number): string {
   if (confidence < 50) return "";
   const minSetups = confidence >= 60 ? 4 : 3;
   return `\nMANDATORY SETUP COUNT (your confidence is ${confidence}%): You MUST provide at least ${minSetups} setups. Returning fewer is a rule violation (r034). Systematically screen ALL instruments — forex majors, indices, crypto, commodities — before concluding no setup exists.\n`;
+}
+
+// ── Confidence computation (three-step pipeline) ──────────
+// Encapsulates the three confidence transformations applied after ORACLE-ANALYSIS:
+//   1. resolveConfidence  — reconcile analysis text vs JSON field (text wins when diff >10pts or cap explicit)
+//   2. Zero-setup floor   — >60% confidence with 0 setups is contradictory → force to 35%
+//   3. applySetupCountPenalty — proportional penalty when setups < minimum for this confidence level
+//
+// Exported so agent.ts can call this once and avoid a second resolveConfidence call that
+// would silently undo any penalty applied in step 3 (backlog #23 double-call bug).
+export function computeOracleConfidence(
+  analysisText: string,
+  jsonConfidence: number,
+  setupCount: number,
+  isWeekend: boolean
+): number {
+  let c = resolveConfidence(analysisText, jsonConfidence);
+  if (c > 60 && setupCount === 0) {
+    console.warn(`  ⚠ ORACLE contradiction: ${c}% confidence but 0 setups — forcing to 35%`);
+    c = 35;
+  }
+  const { penalized, reason } = applySetupCountPenalty(c, setupCount, isWeekend);
+  if (reason) {
+    console.warn(`  ⚠ ORACLE ${reason}`);
+  }
+  return penalized;
 }
 
 // ── r041 screening validation enforcement ─────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence } from "../src/oracle";
+import { resolveConfidence } from "../src/validate";
 import type { MarketSnapshot } from "../src/types";
 
 function makeSnap(changePercent: number): MarketSnapshot {
@@ -1100,5 +1101,65 @@ describe("buildR041ScreeningNote", () => {
     const note = buildR041ScreeningNote();
     expect(note).toMatch(/\[price\]/i);
     expect(note).toMatch(/\[level\]/i);
+  });
+});
+
+// ── computeOracleConfidence ───────────────────────────────
+// Encapsulates the three-step confidence computation in oracle.ts:
+// 1. resolveConfidence (text vs JSON reconciliation)
+// 2. Zero-setup contradiction floor (>60% + 0 setups → 35%)
+// 3. applySetupCountPenalty (proportional penalty)
+//
+// Having this as a named exported function:
+// (a) makes confidence flow unit-testable without mocking the Claude API
+// (b) allows agent.ts to avoid calling resolveConfidence a second time
+//     (which would undo any penalty oracle.ts applied — the latent bug in
+//     backlog #23: text says 65%, penalty reduces to 45%, second call sees
+//     diff=20>10 and silently restores 65%)
+
+describe("computeOracleConfidence", () => {
+  it("returns resolved text confidence when json diverges >10pts", () => {
+    // text=73, json=50 → resolveConfidence returns 73; 4 setups → no penalty
+    expect(computeOracleConfidence("Confidence: 73% — TC(80%), MA(60%), RR(70%)", 50, 4, false)).toBe(73);
+  });
+
+  it("returns 35 when confidence >60 with zero setups (contradiction floor)", () => {
+    expect(computeOracleConfidence("Confidence: 65%", 65, 0, false)).toBe(35);
+  });
+
+  it("applies setup count penalty when below weekday minimum", () => {
+    // 65% confidence, 1 setup, weekday: minSetups=3, shortfall=2, penalty=20pts → 45
+    expect(computeOracleConfidence("Confidence: 65%", 65, 1, false)).toBe(45);
+  });
+
+  it("no penalty when setup count meets minimum for confidence level", () => {
+    // 65% confidence, 3 setups, weekday: minSetups=3, shortfall=0 → no penalty
+    expect(computeOracleConfidence("Confidence: 65%", 65, 3, false)).toBe(65);
+  });
+
+  it("honors explicit cap notation over raw confidence", () => {
+    // text says 'capped at 65%', json=70 → resolveConfidence returns 65; 4 setups → no penalty
+    expect(computeOracleConfidence("Confidence: 70% — capped at 65%", 70, 4, false)).toBe(65);
+  });
+
+  it("penalty is stable — result must not be fed back into resolveConfidence", () => {
+    // This documents the agent.ts double-call bug (backlog #23):
+    // oracle.ts computes final=45 (penalized from 65). If agent.ts then calls
+    // resolveConfidence(analysis_with_65%, 45), diff=20>10 → returns 65 (bug!).
+    // Fix: computeOracleConfidence is called once in oracle.ts; agent.ts must not
+    // call resolveConfidence again.
+    const text = "Confidence: 65% — TC(65%), MA(70%), RR(60%)";
+    const penalized = computeOracleConfidence(text, 65, 1, false);
+    expect(penalized).toBe(45); // penalty applied
+    // If resolveConfidence were called again on the penalized value, it would undo it:
+    // (this was the bug — agent.ts used to do this; now removed)
+    expect(resolveConfidence(text, penalized)).toBe(65); // demonstrates the anti-pattern
+  });
+
+  it("weekend sessions apply minimum 2 setups instead of 3", () => {
+    // weekend, 65% confidence, 2 setups: minSetups=2, no shortfall
+    expect(computeOracleConfidence("Confidence: 65%", 65, 2, true)).toBe(65);
+    // weekend, 65% confidence, 1 setup: minSetups=2, shortfall=1, penalty=10 → 55
+    expect(computeOracleConfidence("Confidence: 65%", 65, 1, true)).toBe(55);
   });
 });


### PR DESCRIPTION
## Problem (backlog #23)

Confidence value was inconsistent across the pipeline. Root cause: `resolveConfidence()` was called **twice**:

1. **oracle.ts line 489** — reconciles text vs JSON, then applies zero-setup floor and `applySetupCountPenalty`
2. **agent.ts line 551** — calls `resolveConfidence()` again on the already-penalized value

If oracle.ts penalized confidence from 65%→45% (e.g. insufficient setups), agent.ts would see the penalized 45% in the JSON but 65% in the analysis text — diff=20>10 — and silently restore 65%, writing the wrong confidence to the journal.

## Fix

Extract the confidence pipeline into `computeOracleConfidence(analysisText, jsonConfidence, setupCount, isWeekend)`:
1. `resolveConfidence` — text vs JSON reconciliation
2. Zero-setup contradiction floor (>60% + 0 setups → 35%)
3. `applySetupCountPenalty` — proportional penalty

Oracle.ts now calls `computeOracleConfidence` once. Agent.ts no longer calls `resolveConfidence` (comment explains why). The `resolveConfidence` import removed from agent.ts.

## Test plan
- [x] `npm test` — 557 tests pass (7 new: full pipeline coverage including penalty stability and anti-pattern documentation)
- [x] `npx tsc --noEmit` — no type errors
- [x] Existing `resolveConfidence` and `applySetupCountPenalty` tests unaffected