### PR TITLE
fix(oracle): clarify neutral entries do not count toward mandatory setup minimum (backlog #26)

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -276,6 +276,7 @@ ${weekendTemplate}
 
   const rawConf = parsed.confidence ?? 50;
   const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
+  const minNonNeutral = rawConf >= 60 ? 4 : 3;
   const weekdayScreeningNote = weekdayTemplate
     ? `\nSYSTEMATIC SCREENING REQUIRED (your confidence is ${rawConf}%):
 You MUST fill in EVERY slot in the JSON template below. Do NOT add or remove slots.
@@ -283,6 +284,8 @@ For each instrument:
   - If a valid structural level exists aligned with your bias → fill in entry, stop, target, RR, timeframe, set direction to "bullish" or "bearish"
   - If no valid setup exists → leave entry/stop/target/RR/timeframe as null, set direction to "neutral", explain briefly in description
 All ${snapshots.length} instruments must be accounted for. Returning fewer slots is a rule violation (r034).
+
+CRITICAL: Neutral entries (direction: "neutral") do NOT count as setups. At confidence ${rawConf}%, you MUST have at least ${minNonNeutral} slots with direction "bullish" or "bearish" and all numeric fields populated. Setting every slot to "neutral" is a direct violation of r034. Your ${biasOverall} bias with documented confluences guarantees structural opportunities exist — commit to them.
 
 START WITH THIS TEMPLATE (fill in every slot):
 ${weekdayTemplate}
@@ -627,7 +630,7 @@ export function buildWeekdayScreeningTemplate(snapshots: MarketSnapshot[], confi
 export function buildMinSetupNote(confidence: number): string {
   if (confidence < 50) return "";
   const minSetups = confidence >= 60 ? 4 : 3;
-  return `\nMANDATORY SETUP COUNT (your confidence is ${confidence}%): You MUST provide at least ${minSetups} setups. Returning fewer is a rule violation (r034). Systematically screen ALL instruments — forex majors, indices, crypto, commodities — before concluding no setup exists.\n`;
+  return `\nMANDATORY SETUP COUNT (your confidence is ${confidence}%): You MUST provide at least ${minSetups} setups with direction "bullish" or "bearish" and all fields populated. Neutral entries (direction: "neutral") do NOT count as setups — they are screened rejections only. Returning fewer than ${minSetups} non-neutral setups is a rule violation (r034). Systematically screen ALL instruments — forex majors, indices, crypto, commodities — before concluding no setup exists.\n`;
 }
 
 // ── Confidence computation (three-step pipeline) ──────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -979,6 +979,17 @@ describe("buildMinSetupNote", () => {
   it("triggers at exactly 50", () => {
     expect(buildMinSetupNote(50)).not.toBe("");
   });
+
+  it("explicitly states that neutral entries do not count as setups (backlog #26)", () => {
+    const note = buildMinSetupNote(72);
+    expect(note.toLowerCase()).toMatch(/neutral.*not count|not count.*neutral|neutral.*do not|neutral entries.*not/i);
+  });
+
+  it("requires non-neutral direction entries, not just array length (backlog #26)", () => {
+    const note = buildMinSetupNote(55);
+    // Must mention bullish/bearish as the required direction
+    expect(note.toLowerCase()).toMatch(/bullish.*bearish|bearish.*bullish|non-neutral/i);
+  });
 });
 
 // ── buildRRSelfCheckNote ──────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause**: Sessions #174, #175, #176 all produced 0 setups at 58–72% confidence because ORACLE was filling all weekday screening template slots with `direction: "neutral"`, which are stripped as `screeningKeyLevels` not counted as setups
- **Fix 1** (`buildMinSetupNote`): Explicitly states that neutral entries do NOT count as setups and the minimum applies to `"bullish"` or `"bearish"` direction entries with all numeric fields populated
- **Fix 2** (`weekdayScreeningNote`): Added a CRITICAL paragraph making clear that at confidence ≥ 50%, at least N slots must be non-neutral — setting everything to neutral at this confidence level is a direct r034 violation

## Test plan

- [ ] 2 new tests verify `buildMinSetupNote` names neutral entries as non-qualifying and requires bullish/bearish direction
- [ ] All 559 existing tests pass
- [ ] Build clean (`tsc` no errors)
- [ ] Next session should produce ≥ 3 non-neutral setups when confidence ≥ 55%