### PR TITLE
test(validate): add coverage for 'Other' type overuse check (backlog #27)

### DIFF
--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1962,3 +1962,86 @@ describe("validateOracleOutput r041 pre-commitment check", () => {
     expect(validateOracleOutput(oracle, []).warnings.some((w) => w.includes("r041"))).toBe(false);
   });
 });
+
+// ── "Other" type overuse enforcement (backlog #27) ────────────
+
+describe('validateOracleOutput "Other" type overuse check', () => {
+  const makeSetupTyped = (instrument: string, type: string): any => ({
+    instrument, type, direction: "bullish",
+    description: "test setup", invalidation: "test",
+    entry: 100, stop: 95, target: 110, RR: 2.0, timeframe: "4H",
+  });
+
+  it("warns when ≥50% of setups use 'Other' at confidence ≥55% (session #177 pattern: 2/3)", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "Strong bullish momentum across asset classes.".padEnd(300, " "),
+      bias: { overall: "bullish", notes: "risk-on" }, confidence: 61,
+      setups: [
+        makeSetupTyped("S&P 500", "PDH/PDL"),
+        makeSetupTyped("Gold", "Other"),
+        makeSetupTyped("Oil", "Other"),
+      ],
+      keyLevels: [], marketSnapshots: [], assumptions: [],
+    };
+    const warnings = validateOracleOutput(oracle, []).warnings;
+    expect(warnings.some((w) => w.toLowerCase().includes("other"))).toBe(true);
+    expect(warnings.some((w) => w.includes("ICT"))).toBe(true);
+  });
+
+  it("warns when all setups use 'Other'", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "Mixed signals across markets.".padEnd(300, " "),
+      bias: { overall: "mixed", notes: "conflicting" }, confidence: 58,
+      setups: [makeSetupTyped("EUR/USD", "Other"), makeSetupTyped("Bitcoin", "Other")],
+      keyLevels: [], marketSnapshots: [], assumptions: [],
+    };
+    const warnings = validateOracleOutput(oracle, []).warnings;
+    expect(warnings.some((w) => w.toLowerCase().includes("other"))).toBe(true);
+  });
+
+  it("does not warn when only 1 of 3 setups uses 'Other' (<50%)", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "Bullish breakout on multiple instruments.".padEnd(300, " "),
+      bias: { overall: "bullish", notes: "momentum" }, confidence: 65,
+      setups: [
+        makeSetupTyped("EUR/USD", "FVG"),
+        makeSetupTyped("NASDAQ", "OB"),
+        makeSetupTyped("Gold", "Other"),
+      ],
+      keyLevels: [], marketSnapshots: [], assumptions: [],
+    };
+    const warnings = validateOracleOutput(oracle, []).warnings;
+    expect(warnings.some((w) => w.toLowerCase().includes("other") && w.includes("ICT"))).toBe(false);
+  });
+
+  it("does not warn when no setups exist", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "No setups today.".padEnd(300, " "),
+      bias: { overall: "neutral", notes: "" }, confidence: 40,
+      setups: [], keyLevels: [], marketSnapshots: [], assumptions: [],
+    };
+    const warnings = validateOracleOutput(oracle, []).warnings;
+    expect(warnings.some((w) => w.toLowerCase().includes("other") && w.includes("ICT"))).toBe(false);
+  });
+
+  it("does not warn when all setups use specific ICT types", () => {
+    const oracle: OracleAnalysis = {
+      sessionId: "test", timestamp: new Date(),
+      analysis: "Clear ICT patterns across instruments.".padEnd(300, " "),
+      bias: { overall: "bullish", notes: "momentum" }, confidence: 70,
+      setups: [
+        makeSetupTyped("EUR/USD", "FVG"),
+        makeSetupTyped("NASDAQ", "OB"),
+        makeSetupTyped("Bitcoin", "Liquidity Sweep"),
+        makeSetupTyped("Gold", "MSS"),
+      ],
+      keyLevels: [], marketSnapshots: [], assumptions: [],
+    };
+    const warnings = validateOracleOutput(oracle, []).warnings;
+    expect(warnings.some((w) => w.toLowerCase().includes("other") && w.includes("ICT"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- The `validateOracleOutput` check that warns when ≥50% of setups use type `"Other"` (instead of specific ICT patterns FVG/OB/Liquidity Sweep/MSS/CISD/PDH/PDL) already existed at line 491-499 but had **zero tests**
- Session #177 confirmed it fires correctly for the 2/3 pattern (67% ≥ 50% threshold)
- This PR adds 5 tests documenting and protecting that behaviour from regression

## What the check does

Warns when `otherCount >= setups.length * 0.5` — i.e. half or more setups use `"Other"` — with a message listing all valid ICT types. This warning feeds into AXIOM's context each session, creating feedback pressure to use specific patterns.

## Test plan

- [x] Warns when 2/3 setups use `"Other"` (session #177 pattern)
- [x] Warns when all setups use `"Other"`
- [x] No warn when 1/3 use `"Other"` (below 50% threshold)
- [x] No warn when no setups exist
- [x] No warn when all setups use specific ICT types
- [x] All 564 tests pass, build clean