### PR TITLE
fix(oracle): pre-reconcile confidence before building ORACLE-SETUPS prompt

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -271,10 +271,17 @@ ${weekendTemplate}
 \n` : "";
 
   const r029Note = buildR029StopNote(snapshots);
-  const minSetupNote = buildMinSetupNote(parsed.confidence ?? 50);
   const rrSelfCheckNote = buildRRSelfCheckNote();
 
-  const rawConf = parsed.confidence ?? 50;
+  // Pre-reconcile confidence before building ORACLE-SETUPS prompt.
+  // ORACLE-ANALYSIS may return a low JSON confidence (e.g. 45) while its analysis
+  // text clearly states a higher value (e.g. 58%). Using the raw JSON field here
+  // meant buildWeekdayScreeningTemplate and buildMinSetupNote received sub-50
+  // confidence and injected NO enforcement into ORACLE-SETUPS — root cause of the
+  // persistent 0-setup sessions (#174-#176, #178). resolveConfidence honours the
+  // text value when JSON diverges >10pts or when cap notation is present.
+  const rawConf = resolveConfidence(parsed.analysis ?? "", parsed.confidence ?? 50);
+  const minSetupNote = buildMinSetupNote(rawConf);
   const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
   const minNonNeutral = rawConf >= 60 ? 4 : 3;
   const weekdayScreeningNote = weekdayTemplate


### PR DESCRIPTION
## Root Cause

`rawConf = parsed.confidence ?? 50` used the raw JSON confidence from ORACLE-ANALYSIS. When ORACLE-ANALYSIS returned `"confidence": 45` in the JSON but wrote `"Confidence: 58%"` in the analysis text:

- `buildWeekdayScreeningTemplate(snapshots, 45)` → `""` (threshold is 50, so no template)
- `buildMinSetupNote(45)` → `""` (same threshold)
- **ORACLE-SETUPS received zero enforcement** → returned `[]`

`computeOracleConfidence()` correctly reconciled to 58% *after* both calls, but the ORACLE-SETUPS prompt had already been built without the template or mandatory setup note. This is why sessions #174–#176 and #178 all produced 0 setups despite 58–72% analysis-text confidence.

## Fix

Apply `resolveConfidence()` to compute `rawConf` **before** building the ORACLE-SETUPS prompt. This is the same reconciliation logic already used downstream — just moved one step earlier so the template generation sees the correct confidence.

Also moves `buildMinSetupNote()` call to after `rawConf` so both use the reconciled value.

## Verification

- Build clean (`tsc` no errors)
- All 564 tests pass
- Next session should show the weekday template injected even when JSON confidence differs from text confidence