### PR TITLE
fix(validate): apply r029 stop requirement per-instrument, not session-wide

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -595,18 +595,23 @@ export function warnPoorRiskReward(setups: any[]): void {
 // for this session based on live market volatility. Empty string = no constraint.
 export function buildR029StopNote(snapshots: MarketSnapshot[]): string {
   if (!snapshots.length) return "";
-  const maxMove = Math.max(...snapshots.map(s => Math.abs(s.changePercent ?? 0)));
-  if (maxMove >= 5) {
-    return `\nMANDATORY STOP REQUIREMENT (r029 — extreme volatility detected: max session move ${maxMove.toFixed(1)}%):
-Every stop MUST be at least 1.5% from entry. Verify before finalising: |entry - stop| / entry ≥ 0.015.
-Do NOT include any setup where the stop is closer than 1.5% from entry.\n`;
+  const extremeInstruments = snapshots.filter(s => Math.abs(s.changePercent ?? 0) >= 5);
+  const moderateInstruments = snapshots.filter(s => {
+    const move = Math.abs(s.changePercent ?? 0);
+    return move >= 3 && move < 5;
+  });
+  if (!extremeInstruments.length && !moderateInstruments.length) return "";
+
+  const lines: string[] = ["\nMANDATORY STOP REQUIREMENT (r029 — per-instrument volatility):"];
+  for (const s of extremeInstruments) {
+    lines.push(`  • ${s.name} (moved ${Math.abs(s.changePercent ?? 0).toFixed(1)}%): stop MUST be ≥1.5% from entry`);
   }
-  if (maxMove >= 3) {
-    return `\nMANDATORY STOP REQUIREMENT (r029 — moderate volatility detected: max session move ${maxMove.toFixed(1)}%):
-Every stop MUST be at least 1.0% from entry. Verify before finalising: |entry - stop| / entry ≥ 0.010.
-Do NOT include any setup where the stop is closer than 1.0% from entry.\n`;
+  for (const s of moderateInstruments) {
+    lines.push(`  • ${s.name} (moved ${Math.abs(s.changePercent ?? 0).toFixed(1)}%): stop MUST be ≥1.0% from entry`);
   }
-  return "";
+  lines.push("Instruments NOT listed above have NO minimum stop requirement from r029.");
+  lines.push("Verify: |entry - stop| / entry meets the threshold for each listed instrument.\n");
+  return lines.join("\n");
 }
 
 // ── Weekday instrument screening template ─────────────────

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -640,17 +640,22 @@ export function filterNonCompliantSetups(oracle: OracleAnalysis): {
   removed: SetupRemovalRecord[];
 } {
   const snapshots = oracle.marketSnapshots ?? [];
-  const maxMove = snapshots.reduce((max, s) => Math.max(max, Math.abs(s.changePercent)), 0);
 
-  const extremeVolatility = maxMove >= 5;
-  const moderateVolatility = maxMove >= 3;
-
-  if (!extremeVolatility && !moderateVolatility) {
-    return { oracle, removed: [] };
+  // Build per-instrument volatility lookup — name and symbol both keyed.
+  // Oil crashing 8.62% should NOT force EUR/USD (moved 0.81%) to need a 177-pip stop.
+  // Each setup's stop requirement is based on THAT instrument's own session move.
+  const volatilityMap = new Map<string, number>();
+  for (const snap of snapshots) {
+    const move = Math.abs(snap.changePercent ?? 0);
+    volatilityMap.set(snap.name.toLowerCase(), move);
+    volatilityMap.set(snap.symbol.toLowerCase().replace(/[^a-z0-9]/g, ""), move);
   }
 
-  const minStopPct = extremeVolatility ? 1.5 : 1.0;
-  const volatilityLabel = extremeVolatility ? "extreme" : "moderate";
+  // Fast-exit: if no instrument in the session had a moderate+ move, nothing to filter.
+  const sessionMaxMove = snapshots.reduce((max, s) => Math.max(max, Math.abs(s.changePercent ?? 0)), 0);
+  if (sessionMaxMove < 3) {
+    return { oracle, removed: [] };
+  }
 
   const removed: SetupRemovalRecord[] = [];
   const compliantSetups: typeof oracle.setups = [];
@@ -660,11 +665,27 @@ export function filterNonCompliantSetups(oracle: OracleAnalysis): {
       typeof s.entry === "number" && s.entry > 0 &&
       typeof s.stop  === "number" && s.stop  > 0
     ) {
+      // Look up this setup's own instrument move, not the session-wide max.
+      const instrKey = (s.instrument ?? "").toLowerCase();
+      const instrKeyNorm = instrKey.replace(/[^a-z0-9]/g, "");
+      const instrMove = volatilityMap.get(instrKey) ?? volatilityMap.get(instrKeyNorm) ?? 0;
+
+      const instrExtreme  = instrMove >= 5;
+      const instrModerate = instrMove >= 3;
+
+      if (!instrExtreme && !instrModerate) {
+        compliantSetups.push(s);
+        continue;
+      }
+
+      const minStopPct    = instrExtreme ? 1.5 : 1.0;
+      const volatilityLabel = instrExtreme ? "extreme" : "moderate";
       const stopPct = (Math.abs(s.entry - s.stop) / s.entry) * 100;
+
       if (stopPct < minStopPct) {
         removed.push({
           instrument: s.instrument ?? "unknown",
-          reason: `r029: stop is ${stopPct.toFixed(2)}% from entry — requires ≥${minStopPct}% during ${volatilityLabel} volatility (session move ${maxMove.toFixed(1)}%)`,
+          reason: `r029: stop is ${stopPct.toFixed(2)}% from entry — requires ≥${minStopPct}% during ${volatilityLabel} volatility (instrument move ${instrMove.toFixed(1)}%)`,
         });
         continue;
       }

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -15,19 +15,17 @@ describe("buildR029StopNote", () => {
     expect(buildR029StopNote(snaps)).toBe("");
   });
 
-  it("returns extreme volatility note when any move >= 5%", () => {
+  it("requires 1.5% stop for instruments that moved >= 5%", () => {
     const snaps = [makeSnap(1.0), makeSnap(5.2), makeSnap(-2.0)];
     const note = buildR029StopNote(snaps);
     expect(note).toContain("1.5%");
-    expect(note).toContain("extreme volatility");
     expect(note).toContain("5.2%");
   });
 
-  it("returns moderate volatility note when max move >= 3% but < 5%", () => {
+  it("requires 1.0% stop for instruments that moved >= 3% but < 5%", () => {
     const snaps = [makeSnap(1.0), makeSnap(3.8), makeSnap(-1.0)];
     const note = buildR029StopNote(snaps);
     expect(note).toContain("1.0%");
-    expect(note).toContain("moderate volatility");
     expect(note).not.toContain("1.5%");
   });
 
@@ -35,7 +33,6 @@ describe("buildR029StopNote", () => {
     const snaps = [makeSnap(-6.0), makeSnap(1.0)];
     const note = buildR029StopNote(snaps);
     expect(note).toContain("1.5%");
-    expect(note).toContain("extreme volatility");
   });
 
   it("returns empty string for empty snapshots array", () => {
@@ -51,8 +48,17 @@ describe("buildR029StopNote", () => {
   it("includes a stop calculation example", () => {
     const snaps = [makeSnap(5.0)];
     const note = buildR029StopNote(snaps);
-    // Should tell ORACLE HOW to verify: |entry - stop| / entry
     expect(note.toLowerCase()).toMatch(/entry.*stop|stop.*entry/);
+  });
+
+  it("only lists volatile instruments — low-move instruments not mentioned with stop requirement (session #179 pattern)", () => {
+    // Oil -8.62% should get 1.5% requirement; EUR/USD 0.81% should get nothing
+    const oilSnap = { symbol: "CL=F",    name: "Crude Oil", category: "commodities" as const, price: 90,    previousClose: 98.16, change: -8.16, changePercent: -8.62, high: 98, low: 89, timestamp: new Date() };
+    const eurSnap = { symbol: "EURUSD=X",name: "EUR/USD",   category: "forex"        as const, price: 1.1786,previousClose: 1.169, change: 0.0095, changePercent: 0.81, high: 1.18, low: 1.17, timestamp: new Date() };
+    const note = buildR029StopNote([oilSnap, eurSnap]);
+    expect(note).toContain("1.5%");          // Oil needs wide stop
+    expect(note).toContain("Crude Oil");     // Oil is named
+    expect(note).not.toContain("EUR/USD");   // EUR/USD is NOT listed — no requirement for it
   });
 });
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1169,9 +1169,9 @@ describe("validateWeekendCryptoScreening", () => {
 // ── filterNonCompliantSetups ─────────────────────────────────
 
 describe("filterNonCompliantSetups", () => {
-  function makeSnap(changePercent: number) {
+  function makeSnap(changePercent: number, name = "NASDAQ 100", symbol = "NAS100") {
     return {
-      symbol: "NAS100", name: "NASDAQ 100", category: "indices" as const,
+      symbol, name, category: "indices" as const,
       price: 25000, previousClose: 25000 / (1 + changePercent / 100),
       change: 25000 * changePercent / 100, changePercent,
       high: 25100, low: 24900, timestamp: new Date(),
@@ -1212,7 +1212,8 @@ describe("filterNonCompliantSetups", () => {
   });
 
   it("removes setup with stop < 1.0% during moderate volatility (3–4.9% session move)", () => {
-    const oracle = makeOracle([makeSnap(3.5)], [makeSetup("GBP/USD", 1.34, 1.333)]); // ~0.52% stop
+    // Snapshot must match setup instrument for per-instrument r029 to apply
+    const oracle = makeOracle([makeSnap(3.5, "GBP/USD", "GBPUSD")], [makeSetup("GBP/USD", 1.34, 1.333)]); // ~0.52% stop
     const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
     expect(filtered.setups).toHaveLength(0);
     expect(removed).toHaveLength(1);
@@ -1233,8 +1234,9 @@ describe("filterNonCompliantSetups", () => {
   });
 
   it("keeps compliant and removes non-compliant in mixed setup list during extreme day", () => {
+    // Both instruments must have snapshots for per-instrument r029 to apply to each
     const oracle = makeOracle(
-      [makeSnap(5.2)],
+      [makeSnap(5.2), makeSnap(5.1, "EUR/USD", "EURUSD")],
       [
         makeSetup("NASDAQ 100", 25000, 24600), // 1.6% stop — compliant
         makeSetup("EUR/USD", 1.17, 1.168),      // 0.17% stop — non-compliant
@@ -1275,6 +1277,71 @@ describe("filterNonCompliantSetups", () => {
     } as any]);
     const { removed } = filterNonCompliantSetups(bearishOracle);
     expect(removed).toHaveLength(1);
+  });
+
+  // ── per-instrument volatility (session #179 root cause) ──────
+  // Oil crashing 8.62% should NOT force EUR/USD to have a 177-pip stop.
+  // Each setup's stop requirement is based on THAT instrument's own move.
+
+  function makeNamedSnap(name: string, symbol: string, changePercent: number) {
+    return {
+      symbol, name, category: "forex" as const,
+      price: 100, previousClose: 100 / (1 + changePercent / 100),
+      change: 100 * changePercent / 100, changePercent,
+      high: 101, low: 99, timestamp: new Date(),
+    };
+  }
+
+  it("does NOT filter EUR/USD tight stop when only Oil moved 8.62% (session #179 pattern)", () => {
+    const snaps = [
+      makeNamedSnap("EUR/USD",   "EURUSD=X", 0.81),   // own move: 0.81% — no requirement
+      makeNamedSnap("Crude Oil", "CL=F",     -8.62),  // causes global max = 8.62%
+    ];
+    const oracle: OracleAnalysis = {
+      timestamp: new Date(), sessionId: "test", marketSnapshots: snaps as any,
+      analysis: "A".repeat(300), setups: [makeSetup("EUR/USD", 1.1786, 1.1750)] as any, // 0.31% stop — fine for 0.81% mover
+      bias: { overall: "bullish", notes: "risk-on" }, keyLevels: [], confidence: 61,
+    };
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect(removed).toHaveLength(0);
+  });
+
+  it("filters Oil setup with tight stop when Oil itself moved 8.62%", () => {
+    const snaps = [
+      makeNamedSnap("EUR/USD",   "EURUSD=X", 0.81),
+      makeNamedSnap("Crude Oil", "CL=F",     -8.62),
+    ];
+    const oracle: OracleAnalysis = {
+      timestamp: new Date(), sessionId: "test", marketSnapshots: snaps as any,
+      analysis: "A".repeat(300), setups: [makeSetup("Crude Oil", 90.0, 89.5)] as any, // 0.56% stop — not enough for 8.62% mover
+      bias: { overall: "bearish", notes: "oil crash" }, keyLevels: [], confidence: 61,
+    };
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(0);
+    expect(removed).toHaveLength(1);
+    expect(removed[0].instrument).toBe("Crude Oil");
+  });
+
+  it("keeps EUR/USD and filters Oil in same session when only Oil is extreme", () => {
+    const snaps = [
+      makeNamedSnap("EUR/USD",   "EURUSD=X", 0.81),
+      makeNamedSnap("Crude Oil", "CL=F",     -8.62),
+    ];
+    const oracle: OracleAnalysis = {
+      timestamp: new Date(), sessionId: "test", marketSnapshots: snaps as any,
+      analysis: "A".repeat(300),
+      setups: [
+        makeSetup("EUR/USD",   1.1786, 1.1750), // 0.31% stop — fine for 0.81% mover
+        makeSetup("Crude Oil", 90.0,   89.5),   // 0.56% stop — not enough for 8.62% mover
+      ] as any,
+      bias: { overall: "mixed", notes: "divergent" }, keyLevels: [], confidence: 61,
+    };
+    const { oracle: filtered, removed } = filterNonCompliantSetups(oracle);
+    expect(filtered.setups).toHaveLength(1);
+    expect((filtered.setups as any)[0].instrument).toBe("EUR/USD");
+    expect(removed).toHaveLength(1);
+    expect(removed[0].instrument).toBe("Crude Oil");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Root cause of session #179 0-setup bug**: `filterNonCompliantSetups` used `Math.max()` across ALL instrument snapshots. When Oil crashed 8.62%, every setup in the session (including EUR/USD at +0.81%) was forced to carry a 1.5% stop — that's 177 pips on EUR/USD at 1.1786, making any realistic target produce RR=0.19, which was then dropped by the self-check.
- **Fix**: Build a `volatilityMap` keyed by instrument name/symbol. Apply the ≥1.5% (extreme) or ≥1.0% (moderate) stop threshold only to the specific instrument that moved that much. Low-move instruments have no requirement.
- **Prompt guidance updated**: `buildR029StopNote` now lists only volatile instruments by name with their specific threshold, and explicitly states other instruments have no minimum stop requirement.

## Changes

- `src/validate.ts`: `filterNonCompliantSetups` rewritten with per-instrument volatility lookup
- `src/oracle.ts`: `buildR029StopNote` updated to list only volatile instruments
- `tests/validate.test.ts`: `makeSnap()` accepts optional name/symbol; two old global-max tests updated to use matching snapshots; 3 new per-instrument tests (session #179 pattern)
- `tests/oracle.test.ts`: existing wording tests updated to be format-agnostic; new per-instrument listing test added

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 568/568 pass
- [ ] Trigger a session after merge to verify setups appear on high-confidence mixed days