### PR TITLE
fix(rules): clarify r029 as per-instrument, not session-wide

### DIFF
--- a/memory/analysis-rules.json
+++ b/memory/analysis-rules.json
@@ -233,7 +233,7 @@
     {
       "id": "r029",
       "category": "setup_precision",
-      "description": "During extreme volatility (session moves â‰¥5%), stop loss must be minimum 1.5% from entry price. During moderate volatility (VIX >25 or daily moves >2x typical range), stops require minimum 1.25% from entry. Calculate and verify stop distance before finalizing any setup during elevated volatility periods.",
+      "description": "Per-instrument stop distance requirement during high volatility. For any instrument that individually moved ≥5% in the session, stop must be ≥1.5% from entry. For instruments that individually moved ≥3% but <5%, stop must be ≥1.0% from entry. Instruments with individual moves below 3% have NO minimum stop requirement from this rule — a large move in one instrument (e.g. Oil -8%) does NOT impose stop requirements on unrelated instruments (e.g. EUR/USD at +0.7%). Apply per-instrument only.",
       "weight": 9,
       "addedSession": 56,
       "lastModifiedSession": 147


### PR DESCRIPTION
## Summary

- **Problem**: After PR #82 fixed the code enforcement to be per-instrument, AXIOM still had the old global r029 description. In session #180 it correctly flagged EUR/USD's 0.31% stop as a r029 violation — but under per-instrument logic, EUR/USD at +0.73% has no minimum stop requirement at all (only Oil at -7.68% does).
- **Fix**: Updated r029 description to explicitly state the rule applies only to the specific instrument that moved ≥5%/≥3%, and that a large move in one instrument does NOT impose stop requirements on unrelated instruments.
- **r042**: Already disabled (unrelated to stops — it's about confidence text/JSON mismatch). No change needed.

## Notes

- `lastModifiedSession` kept at 147 (not bumped to current session) — this is a developer correction, not an AXIOM-driven modification. Bumping it would trigger the 3-session cooldown in `sanitizeAxiomOutput`, blocking any near-term AXIOM modifications to r029.

## Test plan

- [x] `npm test` — 568/568 pass (including the axiom cooldown test that was caught by this exact edge case)