### PR TITLE
fix(axiom): inject per-instrument r029 note so AXIOM stops flagging non-volatile instruments

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -179,6 +179,23 @@ The pipeline enforcement is working as designed. Acknowledge it briefly and move
 - Quantified moves (pips/points/%): ${/\d+(\.\d+)?\s*(pips?|points?|%)/i.test(oracle.analysis) ? "YES" : "NO"}
 - All setups complete (entry/stop/target/RR/TF): ${oracle.setups.every((s: any) => (s as any).entry != null && (s as any).stop != null && (s as any).target != null && (s as any).RR != null && (s as any).timeframe) ? "YES — all " + oracle.setups.length + " setups have required fields" : "NO — some setups missing fields"}
 - Mixed bias justified: ${oracle.bias.overall !== "mixed" ? "N/A (bias is " + oracle.bias.overall + ")" : /conflict|divergen|breakdown/i.test(oracle.bias.notes) ? "YES" : "NO"}
+${(() => {
+  const snaps = oracle.marketSnapshots ?? [];
+  const extreme  = snaps.filter(s => Math.abs(s.changePercent ?? 0) >= 5);
+  const moderate = snaps.filter(s => { const m = Math.abs(s.changePercent ?? 0); return m >= 3 && m < 5; });
+  const lowMove  = snaps.filter(s => Math.abs(s.changePercent ?? 0) < 3);
+  if (!extreme.length && !moderate.length) return "";
+  const lines: string[] = [
+    "",
+    "### r029 per-instrument stop requirement — THIS SESSION:",
+    "r029 applies only to instruments that individually moved ≥5% or ≥3% in this session.",
+  ];
+  if (extreme.length)  lines.push("  ≥5% (requires ≥1.5% stop): " + extreme.map(s => `${s.name} (${(s.changePercent ?? 0).toFixed(1)}%)`).join(", "));
+  if (moderate.length) lines.push("  ≥3% (requires ≥1.0% stop): " + moderate.map(s => `${s.name} (${(s.changePercent ?? 0).toFixed(1)}%)`).join(", "));
+  if (lowMove.length)  lines.push("  NOT subject to r029 (moved <3%): " + lowMove.map(s => s.name).join(", ") + " — tight stops on these instruments are NOT r029 violations.");
+  lines.push("Do NOT flag stops on instruments in the 'NOT subject' list as r029 violations.");
+  return lines.join("\n");
+})()}
 
 IMPORTANT ANTI-REPETITION RULES:
 - If a CONFIDENCE ADJUSTMENT NOTICE appeared above, you MUST NOT treat the pipeline enforcement as a rule execution failure or "output mechanism corruption". Do not mention confidence methodology inconsistency in whatFailed. Do not modify r014 or r032.
@@ -381,7 +398,7 @@ export function parseAxiomResponse(
   }
 
   // ── Security: sanitize AXIOM output before applying to memory ──
-  const secResult = sanitizeAxiomOutput(rawParsed, sessionNumber, currentRules.rules.length);
+  const secResult = sanitizeAxiomOutput(rawParsed, sessionNumber, currentRules.rules.length, currentRules.rules);
   if (secResult.warnings.length > 0) {
     for (const w of secResult.warnings) console.warn(`  🛡️  Security: ${w}`);
   }

--- a/src/security.ts
+++ b/src/security.ts
@@ -203,9 +203,10 @@ export interface AxiomSecurityResult {
 }
 
 export function sanitizeAxiomOutput(
-    parsed:           any,
-    sessionNumber:    number,
-    currentRuleCount: number = 10
+    parsed:                    any,
+    sessionNumber:             number,
+    currentRuleCount:          number = 10,
+    cooldownRulesOverride?:    any[]
 ): AxiomSecurityResult {
     const warnings:        string[] = [];
     let   blockedRules     = 0;
@@ -252,14 +253,16 @@ export function sanitizeAxiomOutput(
     const safeUpdates: any[] = [];
     let   removalCount = 0;
 
-    // Load current rules for cooldown check
+    // Load current rules for cooldown check (use override if provided — avoids disk reads in tests)
     const COOLDOWN_SESSIONS = 3;
-    let currentRulesForCooldown: any[] = [];
-    try {
-        const rulesPath = require("path").join(process.cwd(), "memory", "analysis-rules.json");
-        const rulesData = JSON.parse(require("fs").readFileSync(rulesPath, "utf-8"));
-        currentRulesForCooldown = rulesData.rules ?? [];
-    } catch { /* ignore */ }
+    let currentRulesForCooldown: any[] = cooldownRulesOverride ?? [];
+    if (!cooldownRulesOverride) {
+        try {
+            const rulesPath = require("path").join(process.cwd(), "memory", "analysis-rules.json");
+            const rulesData = JSON.parse(require("fs").readFileSync(rulesPath, "utf-8"));
+            currentRulesForCooldown = rulesData.rules ?? [];
+        } catch { /* ignore */ }
+    }
 
     for (const update of rawUpdates) {
         // Block re-modifying a rule that was changed within the last N sessions

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -164,6 +164,48 @@ describe("buildAxiomPrompt", () => {
     expect(userMessage).toContain("bearish");
     expect(userMessage).toContain("Weak structure");
   });
+
+  it("includes r029 per-instrument note listing only volatile instruments when session has extreme mover", () => {
+    const snapshots = [
+      { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 91, previousClose: 99, change: -8, changePercent: -7.82, high: 99, low: 91, timestamp: new Date() },
+      { name: "EUR/USD",   symbol: "EURUSD", category: "forex" as const, price: 1.178, previousClose: 1.169, change: 0.009, changePercent: 0.75, high: 1.18, low: 1.17, timestamp: new Date() },
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    // Should tell AXIOM which instruments r029 applies to
+    expect(userMessage).toContain("r029 applies only to");
+    expect(userMessage).toContain("Crude Oil");
+    // Should explicitly exempt EUR/USD
+    expect(userMessage).toContain("EUR/USD");
+    expect(userMessage).toMatch(/EUR\/USD.*NOT subject|NOT.*r029.*EUR\/USD|no.*r029.*requirement.*EUR\/USD/i);
+  });
+
+  it("does not include r029 per-instrument note when no instruments moved ≥3%", () => {
+    const snapshots = [
+      { name: "EUR/USD", symbol: "EURUSD", category: "forex" as const, price: 1.178, previousClose: 1.169, change: 0.009, changePercent: 0.75, high: 1.18, low: 1.17, timestamp: new Date() },
+      { name: "GBP/USD", symbol: "GBPUSD", category: "forex" as const, price: 1.35, previousClose: 1.34, change: 0.01, changePercent: 0.75, high: 1.36, low: 1.34, timestamp: new Date() },
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    expect(userMessage).not.toContain("r029 applies only to");
+  });
+
+  it("lists both extreme and moderate volatile instruments in r029 note", () => {
+    const snapshots = [
+      { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 91, previousClose: 99, change: -8, changePercent: -7.82, high: 99, low: 91, timestamp: new Date() },
+      { name: "Silver",   symbol: "XAG", category: "commodities" as const, price: 32, previousClose: 31, change: 1, changePercent: 3.5, high: 32.5, low: 31, timestamp: new Date() },
+      { name: "EUR/USD",  symbol: "EURUSD", category: "forex" as const, price: 1.178, previousClose: 1.169, change: 0.009, changePercent: 0.75, high: 1.18, low: 1.17, timestamp: new Date() },
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    expect(userMessage).toContain("Crude Oil");
+    expect(userMessage).toContain("Silver");
+    // EUR/USD should be explicitly exempted
+    expect(userMessage).toMatch(/EUR\/USD.*NOT subject|NOT.*r029.*EUR\/USD|no.*r029.*requirement.*EUR\/USD/i);
+  });
 });
 
 // ── parseAxiomResponse ────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Problem**: AXIOM kept identifying EUR/USD (0.33% stop) and AUD/USD (0.64% stop) as r029 violations in sessions #180-#181, even though those instruments moved <1% individually and have NO minimum stop requirement under the per-instrument logic from PR #82.
- **Fix 1**: `buildAxiomPrompt` now injects a dynamic r029 compliance note listing exactly which instruments need wide stops this session (those that moved ≥5% or ≥3%), and explicitly listing all other instruments as "NOT subject to r029 — tight stops are NOT violations."
- **Fix 2**: `sanitizeAxiomOutput` now accepts an optional `cooldownRulesOverride` parameter; `parseAxiomResponse` passes `currentRules.rules`. This eliminates a class of test fragility where AXIOM modifying a rule in a live session (e.g., setting `r029.lastModifiedSession=181`) would break the cooldown test, which uses `sessionNumber=150`.

## Changes

- `src/axiom.ts`: dynamic r029 per-instrument note in `buildAxiomPrompt`; passes `currentRules.rules` to `sanitizeAxiomOutput`
- `src/security.ts`: `sanitizeAxiomOutput` accepts optional `cooldownRulesOverride` — uses it if provided, falls back to disk read otherwise
- `tests/axiom.test.ts`: 3 new tests for the per-instrument note; cooldown test now uses inline rules via `currentRules.rules` and won't break when AXIOM modifies r029 in future sessions

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 571/571 pass (3 new tests added)