### PR TITLE
fix(axiom): show per-setup r029 COMPLIANT/VIOLATION verdict to stop false violation reports

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -185,15 +185,53 @@ ${(() => {
   const moderate = snaps.filter(s => { const m = Math.abs(s.changePercent ?? 0); return m >= 3 && m < 5; });
   const lowMove  = snaps.filter(s => Math.abs(s.changePercent ?? 0) < 3);
   if (!extreme.length && !moderate.length) return "";
+
+  // Build volatility lookup map
+  const volatilityMap = new Map<string, number>();
+  for (const s of snaps) {
+    const move = Math.abs(s.changePercent ?? 0);
+    volatilityMap.set(s.name.toLowerCase(), move);
+    volatilityMap.set(s.symbol.toLowerCase().replace(/[^a-z0-9]/g, ""), move);
+  }
+
   const lines: string[] = [
     "",
     "### r029 per-instrument stop requirement — THIS SESSION:",
-    "r029 applies only to instruments that individually moved ≥5% or ≥3% in this session.",
+    "r029 applies ONLY to instruments that individually moved ≥5% or ≥3%. Other instruments have NO minimum stop requirement.",
   ];
   if (extreme.length)  lines.push("  ≥5% (requires ≥1.5% stop): " + extreme.map(s => `${s.name} (${(s.changePercent ?? 0).toFixed(1)}%)`).join(", "));
   if (moderate.length) lines.push("  ≥3% (requires ≥1.0% stop): " + moderate.map(s => `${s.name} (${(s.changePercent ?? 0).toFixed(1)}%)`).join(", "));
-  if (lowMove.length)  lines.push("  NOT subject to r029 (moved <3%): " + lowMove.map(s => s.name).join(", ") + " — tight stops on these instruments are NOT r029 violations.");
-  lines.push("Do NOT flag stops on instruments in the 'NOT subject' list as r029 violations.");
+  if (lowMove.length)  lines.push("  NOT subject to r029 (moved <3%): " + lowMove.map(s => s.name).join(", ") + " — ANY stop size is valid for these instruments.");
+
+  // Per-setup validation results so AXIOM sees explicit COMPLIANT/VIOLATION verdicts
+  const setups = oracle.setups ?? [];
+  const setupLines: string[] = [];
+  for (const setup of setups) {
+    if (typeof (setup as any).entry !== "number" || typeof (setup as any).stop !== "number") continue;
+    const instrKey = ((setup as any).instrument ?? "").toLowerCase();
+    const instrKeyNorm = instrKey.replace(/[^a-z0-9]/g, "");
+    const instrMove = volatilityMap.get(instrKey) ?? volatilityMap.get(instrKeyNorm) ?? 0;
+    const stopPct = (Math.abs((setup as any).entry - (setup as any).stop) / (setup as any).entry) * 100;
+    let verdict: string;
+    if (instrMove >= 5) {
+      verdict = stopPct >= 1.5
+        ? `COMPLIANT (moved ${instrMove.toFixed(1)}%, requires ≥1.5%, stop is ${stopPct.toFixed(2)}% ✓)`
+        : `VIOLATION (moved ${instrMove.toFixed(1)}%, requires ≥1.5%, stop is only ${stopPct.toFixed(2)}% ✗)`;
+    } else if (instrMove >= 3) {
+      verdict = stopPct >= 1.0
+        ? `COMPLIANT (moved ${instrMove.toFixed(1)}%, requires ≥1.0%, stop is ${stopPct.toFixed(2)}% ✓)`
+        : `VIOLATION (moved ${instrMove.toFixed(1)}%, requires ≥1.0%, stop is only ${stopPct.toFixed(2)}% ✗)`;
+    } else {
+      verdict = `COMPLIANT (moved ${instrMove.toFixed(1)}%, no r029 minimum applies — any stop is valid)`;
+    }
+    setupLines.push(`  - ${(setup as any).instrument}: stop ${stopPct.toFixed(2)}% — ${verdict}`);
+  }
+  if (setupLines.length) {
+    lines.push("");
+    lines.push("r029 validation per setup (authoritative — do not contradict these verdicts):");
+    lines.push(...setupLines);
+    lines.push("Stops marked COMPLIANT are NOT r029 violations. Do NOT report them as failures.");
+  }
   return lines.join("\n");
 })()}
 

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -174,7 +174,7 @@ describe("buildAxiomPrompt", () => {
     const rules = makeRules();
     const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
     // Should tell AXIOM which instruments r029 applies to
-    expect(userMessage).toContain("r029 applies only to");
+    expect(userMessage).toMatch(/r029 applies only to|r029 applies ONLY to/i);
     expect(userMessage).toContain("Crude Oil");
     // Should explicitly exempt EUR/USD
     expect(userMessage).toContain("EUR/USD");
@@ -205,6 +205,53 @@ describe("buildAxiomPrompt", () => {
     expect(userMessage).toContain("Silver");
     // EUR/USD should be explicitly exempted
     expect(userMessage).toMatch(/EUR\/USD.*NOT subject|NOT.*r029.*EUR\/USD|no.*r029.*requirement.*EUR\/USD/i);
+  });
+
+  it("shows per-setup r029 COMPLIANT status for low-move instrument with tight stop", () => {
+    // EUR/USD moved 0.75% — no r029 minimum. Tight stop should be COMPLIANT.
+    const snapshots = [
+      { name: "Crude Oil", symbol: "OIL",    category: "commodities" as const, price: 91,    previousClose: 99,    change: -8,    changePercent: -7.82, high: 99,    low: 91,    timestamp: new Date() },
+      { name: "EUR/USD",   symbol: "EURUSD", category: "forex" as const,       price: 1.1781, previousClose: 1.169, change: 0.009, changePercent: 0.75,  high: 1.18,  low: 1.17,  timestamp: new Date() },
+    ];
+    const setups: any[] = [
+      { instrument: "EUR/USD", type: "MSS", direction: "bullish", description: "test", invalidation: "test",
+        entry: 1.1781, stop: 1.174, target: 1.19, RR: 1.68, timeframe: "4H" },
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots, setups });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    // EUR/USD stop is 0.35%, but EUR/USD moved 0.75% — no r029 minimum → COMPLIANT
+    expect(userMessage).toMatch(/EUR\/USD.*COMPLIANT|COMPLIANT.*EUR\/USD/i);
+    expect(userMessage).toMatch(/no.*minimum|no.*requirement|no.*r029/i);
+  });
+
+  it("shows per-setup r029 COMPLIANT status for Oil setup meeting 1.5% requirement", () => {
+    const snapshots = [
+      { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 91.47, previousClose: 99.5, change: -8.03, changePercent: -8.07, high: 99, low: 91, timestamp: new Date() },
+    ];
+    const setups: any[] = [
+      { instrument: "Crude Oil", type: "Liquidity Sweep", direction: "bearish", description: "test", invalidation: "test",
+        entry: 91.47, stop: 95, target: 85, RR: 1.83, timeframe: "4H" },
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots, setups });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    // Oil stop is 3.86% — above 1.5% requirement → COMPLIANT
+    expect(userMessage).toMatch(/Crude Oil.*COMPLIANT|COMPLIANT.*Crude Oil/i);
+  });
+
+  it("shows per-setup r029 VIOLATION for Oil setup with stop below 1.5%", () => {
+    const snapshots = [
+      { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 91.47, previousClose: 99.5, change: -8.03, changePercent: -8.07, high: 99, low: 91, timestamp: new Date() },
+    ];
+    const setups: any[] = [
+      { instrument: "Crude Oil", type: "Liquidity Sweep", direction: "bearish", description: "test", invalidation: "test",
+        entry: 91.47, stop: 92, target: 85, RR: 1.83, timeframe: "4H" }, // stop is only 0.58% — violation
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots, setups });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    expect(userMessage).toMatch(/Crude Oil.*VIOLATION|VIOLATION.*Crude Oil/i);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem**: Sessions #180-#182 — AXIOM kept flagging EUR/USD (0.35%), AUD/USD (0.80%), EUR/JPY (0.83%), GBP/JPY (0.90%) stops as r029 violations despite: (1) those instruments only moving <1.2%, well below the 3% threshold, and (2) PR #84 adding an explicit exemption note. AXIOM's global-volatility reasoning ("session has extreme volatility → all stops must be wide") overrode the per-instrument note. Session #182 produced a false self-task #85 about this.
- **Fix**: `buildAxiomPrompt` now emits an authoritative per-setup r029 validation table with explicit COMPLIANT/VIOLATION verdicts for every setup. AXIOM is told these verdicts are authoritative and must not be contradicted.

## Example output injected into AXIOM prompt (session #182 pattern)

```
r029 validation per setup (authoritative — do not contradict these verdicts):
  - EUR/USD: stop 0.35% — COMPLIANT (moved 0.75%, no r029 minimum applies — any stop is valid)
  - AUD/USD: stop 0.80% — COMPLIANT (moved 1.14%, no r029 minimum applies — any stop is valid)
  - Crude Oil: stop 3.52% — COMPLIANT (moved 7.87%, requires ≥1.5%, stop is 3.52% ✓)
Stops marked COMPLIANT are NOT r029 violations. Do NOT report them as failures.
```

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 574/574 pass (3 new per-setup validation tests added)