### PR TITLE
fix(axiom): suppress r029 false-positive self-tasks when all setups are per-instrument compliant

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -6,7 +6,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { createSelfTask, closeSelfTask, SelfTask } from "./self-tasks";
 import { sanitizeAxiomOutput, getMaxOutputTokens, getMaxSystemPromptLength } from "./security";
-import { validateAxiomOutput, logFailure, extractConfidenceFromText, calculateTextSimilarity, detectAxiomRumination, detectAcknowledgedGap } from "./validate";
+import { validateAxiomOutput, logFailure, extractConfidenceFromText, calculateTextSimilarity, detectAxiomRumination, detectAcknowledgedGap, computeR029ActualViolations } from "./validate";
 import { loadAllJournalEntries } from "./journal";
 import {
   salvageJSON, stripSurrogates, extractJSONFromResponse,
@@ -495,6 +495,20 @@ export function parseAxiomResponse(
           priority: "high",
         },
       ];
+    }
+  }
+
+  // r029 false-positive suppression: if AXIOM complained about r029/stop violations
+  // but all setups are actually per-instrument compliant, remove the injected self-task.
+  // This prevents repeated false alerts when AXIOM applies global-max reasoning despite
+  // the per-instrument compliance verdicts injected into its prompt.
+  if (oracle && /r029|stop distance|stop.*violation|violation.*stop/i.test(rawParsed.whatFailed ?? "")) {
+    const actualViolations = computeR029ActualViolations(oracle);
+    if (actualViolations.length === 0) {
+      parsed.newSelfTasks = (parsed.newSelfTasks ?? []).filter(
+        (t: any) => t.category !== "rule-gap"
+      );
+      console.warn("  ⚠ Axiom: r029 false positive suppressed — AXIOM cited stop violations but all setups are per-instrument compliant");
     }
   }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -762,6 +762,37 @@ const VIOLATION_KEYWORDS = [
   "enforcement rather than", "requires code enforcement",
 ];
 
+// ── r029 False-Positive Detector ─────────────────────────
+// Returns the list of setup instruments that genuinely violate r029
+// under the per-instrument logic. An empty list means AXIOM's complaint
+// is a false positive — no setups actually failed r029.
+export function computeR029ActualViolations(oracle: {
+  marketSnapshots?: any[];
+  setups?: any[];
+}): string[] {
+  const snaps = oracle.marketSnapshots ?? [];
+  const setups = oracle.setups ?? [];
+
+  const volatilityMap = new Map<string, number>();
+  for (const s of snaps) {
+    const move = Math.abs(s.changePercent ?? 0);
+    volatilityMap.set((s.name ?? "").toLowerCase(), move);
+    volatilityMap.set((s.symbol ?? "").toLowerCase().replace(/[^a-z0-9]/g, ""), move);
+  }
+
+  const violations: string[] = [];
+  for (const setup of setups) {
+    if (typeof setup.entry !== "number" || typeof setup.stop !== "number") continue;
+    const instrKey = (setup.instrument ?? "").toLowerCase();
+    const instrKeyNorm = instrKey.replace(/[^a-z0-9]/g, "");
+    const instrMove = volatilityMap.get(instrKey) ?? volatilityMap.get(instrKeyNorm) ?? 0;
+    const stopPct = Math.abs(setup.entry - setup.stop) / setup.entry * 100;
+    if (instrMove >= 5 && stopPct < 1.5) violations.push(setup.instrument ?? "unknown");
+    else if (instrMove >= 3 && stopPct < 1.0) violations.push(setup.instrument ?? "unknown");
+  }
+  return violations;
+}
+
 export function detectAxiomRumination(parsed: {
   whatFailed?: string;
   ruleUpdates?: any[];

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -513,6 +513,58 @@ describe("parseAxiomResponse forced self-task injection", () => {
     const ruleGapCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap").length;
     expect(ruleGapCount).toBe(1); // only the one AXIOM already created, not a duplicate
   });
+
+  it("suppresses r029 self-task when AXIOM falsely claims violations but all setups are per-instrument compliant", () => {
+    // Session #183 pattern: Oil -8.17% extreme, EUR/USD +0.79% and EUR/JPY +0.84% (both <3%, no r029 req)
+    // AXIOM falsely flags EUR/USD and EUR/JPY stops as r029 violations
+    const oracle = makeOracle({
+      marketSnapshots: [
+        { name: "Crude Oil", symbol: "OIL",    category: "commodities" as const, price: 91,     previousClose: 99,    change: -8,    changePercent: -8.17, high: 99,   low: 91,   timestamp: new Date() },
+        { name: "EUR/USD",   symbol: "EURUSD",  category: "forex" as const,       price: 1.1783, previousClose: 1.169, change: 0.009, changePercent: 0.79,  high: 1.18, low: 1.17, timestamp: new Date() },
+        { name: "EUR/JPY",   symbol: "EURJPY",  category: "forex" as const,       price: 187.55, previousClose: 186,   change: 1.55,  changePercent: 0.84,  high: 188,  low: 186,  timestamp: new Date() },
+      ] as any,
+      setups: [
+        { instrument: "EUR/USD", type: "MSS",  direction: "bullish", description: "test", invalidation: "test", entry: 1.1783, stop: 1.176,  target: 1.182, RR: 1.61, timeframe: "1H" },
+        { instrument: "EUR/JPY", type: "MSS",  direction: "bullish", description: "test", invalidation: "test", entry: 187.55, stop: 186.5, target: 189,   RR: 1.38, timeframe: "1H" },
+      ] as any,
+    });
+    const json = JSON.stringify({
+      whatWorked: "Good analysis",
+      whatFailed: "EUR/USD 0.20% and EUR/JPY 0.56% stops both below required 1.5% during extreme volatility — r029 stop distance violation for fourth consecutive session",
+      cognitiveBiases: ["enforcement bias"],
+      evolutionSummary: "Need code-level enforcement",
+      ruleUpdates: [], newRules: [], systemPromptAdditions: "",
+      newSelfTasks: [], resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 183, rules, oracle);
+    // All setups are compliant (EUR/USD and EUR/JPY both moved <3%) — false positive must be suppressed
+    const ruleGapCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap").length;
+    expect(ruleGapCount).toBe(0);
+  });
+
+  it("does NOT suppress r029 self-task when a setup truly violates r029 (Oil tight stop)", () => {
+    // Oil moved -8.17% (extreme) — Oil setup has 0.58% stop which IS a real violation (< 1.5%)
+    const oracle = makeOracle({
+      marketSnapshots: [
+        { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 91.47, previousClose: 99.5, change: -8.03, changePercent: -8.17, high: 99, low: 91, timestamp: new Date() },
+      ] as any,
+      setups: [
+        { instrument: "Crude Oil", type: "Liquidity Sweep", direction: "bearish", description: "test", invalidation: "test", entry: 91.47, stop: 92, target: 85, RR: 1.83, timeframe: "4H" },
+      ] as any,
+    });
+    const json = JSON.stringify({
+      whatWorked: "Good analysis",
+      whatFailed: "Crude Oil stop is only 0.58% during extreme session — r029 violation, requires 1.5% minimum",
+      cognitiveBiases: [],
+      evolutionSummary: "Need wider stops on volatile instruments",
+      ruleUpdates: [], newRules: [], systemPromptAdditions: "",
+      newSelfTasks: [], resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 183, rules, oracle);
+    // Oil truly violated r029 — self-task should be injected
+    const ruleGapCount = (result.newSelfTasks ?? []).filter((t: any) => t.category === "rule-gap").length;
+    expect(ruleGapCount).toBe(1);
+  });
 });
 
 // ── buildAxiomPrompt — session type context ───────────────


### PR DESCRIPTION
## Summary

- Adds `computeR029ActualViolations()` to `validate.ts` — checks each setup's stop distance only against its own instrument's move percentage, not a global maximum
- In `parseAxiomResponse` (axiom.ts), after rumination injection, removes injected `rule-gap` self-tasks when AXIOM's `whatFailed` mentions r029/stop violations but no actual per-instrument violations exist
- Two new tests covering: (1) false positive suppressed when EUR/USD + EUR/JPY stops are fine despite Oil extreme move, (2) real violation preserved when Oil setup has a tight stop during Oil's own extreme move

## Why

Sessions #181–#183 showed AXIOM repeatedly filing r029 self-tasks against EUR/USD and EUR/JPY stops that were actually compliant — AXIOM's reasoning was applying global-max logic ("Oil moved 8%, so ALL stops need 1.5%") despite per-instrument compliance verdicts injected into its prompt. Code-level suppression is the only reliable fix.

## Test plan

- [ ] `npm test` — 576 tests pass (2 new axiom tests included)
- [ ] `npm run build` — clean TypeScript compile
- [ ] Run session after merge to confirm no false r029 self-tasks opened