### PR TITLE
fix(oracle): inject r039/r040 cross-asset coverage requirement into ORACLE-SETUPS prompt

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -281,6 +281,7 @@ ${weekendTemplate}
   // persistent 0-setup sessions (#174-#176, #178). resolveConfidence honours the
   // text value when JSON diverges >10pts or when cap notation is present.
   const rawConf = resolveConfidence(parsed.analysis ?? "", parsed.confidence ?? 50);
+  const crossAssetNote = !isWeekend ? buildR039R040CrossAssetNote(snapshots, rawConf) : "";
   const minSetupNote = buildMinSetupNote(rawConf);
   const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
   const minNonNeutral = rawConf >= 60 ? 4 : 3;
@@ -324,7 +325,7 @@ RULES:
 - Weekend crypto sessions: at least 2 setups from available crypto instruments regardless of confidence
 - Every setup MUST have: entry, stop, target, RR, timeframe
 - ENTRY: nearest support/resistance, session high/low, or key level
-- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}
+- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}${crossAssetNote}
 - TARGET: next liquidity level, psychological number, or swing point
 - RR must be > 1.3 \u2014 do not include setups with risk exceeding reward${rrSelfCheckNote}
 - Include instrument, type, direction, description, and invalidation
@@ -686,6 +687,57 @@ export function buildR041ScreeningNote(): string {
    Replace [price] with the current instrument price and [level] with the key support/resistance level you identified.
    If your confidence is ≤55%, you may omit this line.
    This line is required BEFORE you proceed to any other content.
+`;
+}
+
+// ── r039/r040 cross-asset coverage requirement ────────────
+// Returns a prompt block requiring ORACLE to span ≥2 asset classes when:
+//   r039: confidence ≥55% AND 3+ asset classes each have an instrument moving >2%
+//   r040: confidence ≥60% with any market conditions
+// Injected into ORACLE-SETUPS prompt pre-construction so ORACLE knows before
+// committing to setups — not caught post-hoc by validateOracleOutput.
+// Root cause of sessions #181-#183: ORACLE produced only forex setups at 67%
+// confidence despite indices, crypto, and commodities all moving >2%.
+export function buildR039R040CrossAssetNote(snapshots: MarketSnapshot[], confidence: number): string {
+  if (confidence < 55) return "";
+
+  function classifySnap(name: string, symbol: string): string {
+    const n = (name ?? "").toLowerCase();
+    const s = (symbol ?? "").toLowerCase().replace(/[^a-z]/g, "");
+    if (["bitcoin","ethereum","btc","eth","bnb","sol","ada","dot","link","xrp","matic","avax"].some(t => n.includes(t) || s.includes(t))) return "crypto";
+    if (["nasdaq","nas100","s&p","spx","dow","djia","dax","ftse","nikkei"].some(t => n.includes(t) || s.includes(t))) return "indices";
+    if (["gold","silver","oil","crude","copper","natgas","platinum","xau","xag"].some(t => n.includes(t) || s.includes(t))) return "commodities";
+    return "forex";
+  }
+
+  const classesWithBigMoves = new Set<string>();
+  for (const s of snapshots) {
+    if (Math.abs(s.changePercent ?? 0) >= 2) {
+      classesWithBigMoves.add(classifySnap(s.name, s.symbol));
+    }
+  }
+
+  const r039Triggers = classesWithBigMoves.size >= 3;
+  const r040Triggers = confidence >= 60;
+
+  if (!r039Triggers && !r040Triggers) return "";
+
+  const rules = r039Triggers && r040Triggers ? "r039 + r040" : r039Triggers ? "r039" : "r040";
+  const movingClasses = [...classesWithBigMoves].join(", ");
+  const coordinatedContext = r039Triggers
+    ? ` with ${classesWithBigMoves.size} asset classes moving >2% (${movingClasses})`
+    : "";
+
+  return `
+CROSS-ASSET COVERAGE REQUIREMENT (${rules} — MANDATORY):
+Your confidence is ${confidence}%${coordinatedContext}.
+You MUST either:
+  (1) Include setups from AT LEAST 2 DIFFERENT asset classes (forex, indices, crypto, commodities), OR
+  (2) For each asset class NOT covered by a setup, explicitly reject it with quantified reasons:
+      • Poor RR (<1.3) at the identified structural level
+      • Stop distance >2% required
+      • Conflicting higher timeframe structure
+Submitting only forex setups when indices, crypto, and commodities are all moving is a RULE VIOLATION.
 `;
 }
 

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote } from "../src/oracle";
 import { resolveConfidence } from "../src/validate";
 import type { MarketSnapshot } from "../src/types";
 
@@ -1178,5 +1178,86 @@ describe("computeOracleConfidence", () => {
     expect(computeOracleConfidence("Confidence: 65%", 65, 2, true)).toBe(65);
     // weekend, 65% confidence, 1 setup: minSetups=2, shortfall=1, penalty=10 → 55
     expect(computeOracleConfidence("Confidence: 65%", 65, 1, true)).toBe(55);
+  });
+});
+
+// ── buildR039R040CrossAssetNote ───────────────────────────
+
+function makeCrossSnap(name: string, symbol: string, changePct: number) {
+  return { name, symbol, changePercent: changePct, price: 100, change: changePct };
+}
+
+describe("buildR039R040CrossAssetNote", () => {
+  const multiClassSnaps = [
+    makeCrossSnap("EUR/USD",      "EURUSD",  0.79),   // forex  <2% — small move
+    makeCrossSnap("NASDAQ 100",   "NAS100",  4.65),   // indices >2%
+    makeCrossSnap("Bitcoin",      "BTC",     5.15),   // crypto  >2%
+    makeCrossSnap("Crude Oil",    "OIL",    -7.87),   // commodities >2%
+    makeCrossSnap("Gold",         "GOLD",    1.44),   // commodities <2%
+    makeCrossSnap("EUR/JPY",      "EURJPY",  0.84),   // forex <2%
+  ];
+
+  it("returns empty string when confidence < 55 (neither rule triggers)", () => {
+    expect(buildR039R040CrossAssetNote(multiClassSnaps, 50)).toBe("");
+    expect(buildR039R040CrossAssetNote(multiClassSnaps, 40)).toBe("");
+  });
+
+  it("returns empty string when confidence 55-59 and fewer than 3 classes moving >2% (r039 not triggered, r040 not triggered)", () => {
+    // Only 1 class with a big move — r039 needs 3+, r040 needs ≥60
+    const fewSnaps = [
+      makeCrossSnap("EUR/USD", "EURUSD",  2.5),  // forex >2%
+      makeCrossSnap("GBP/USD", "GBPUSD",  0.5),  // forex <2%
+      makeCrossSnap("Bitcoin", "BTC",     1.0),  // crypto <2%
+    ];
+    expect(buildR039R040CrossAssetNote(fewSnaps, 57)).toBe("");
+  });
+
+  it("returns non-empty when confidence ≥55 and 3+ asset classes have moves >2% (r039)", () => {
+    // multiClassSnaps: indices, crypto, commodities all >2% → r039 triggers at 57%
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 57);
+    expect(note.length).toBeGreaterThan(0);
+  });
+
+  it("returns non-empty when confidence ≥60 regardless of move count (r040)", () => {
+    // Only 1 class moving >2% — r039 not triggered, but r040 triggers at ≥60
+    const fewSnaps = [
+      makeCrossSnap("EUR/USD", "EURUSD", 2.5),
+      makeCrossSnap("GBP/USD", "GBPUSD", 0.5),
+    ];
+    const note = buildR039R040CrossAssetNote(fewSnaps, 67);
+    expect(note.length).toBeGreaterThan(0);
+  });
+
+  it("note requires setups from ≥2 different asset classes", () => {
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 67);
+    expect(note).toMatch(/2.*(different|asset class)/i);
+  });
+
+  it("note names the four asset classes ORACLE must screen", () => {
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 67);
+    expect(note.toLowerCase()).toContain("forex");
+    expect(note.toLowerCase()).toContain("indices");
+    expect(note.toLowerCase()).toContain("crypto");
+    expect(note.toLowerCase()).toMatch(/commodit/i);
+  });
+
+  it("note flags only-forex setups as a violation", () => {
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 67);
+    expect(note.toLowerCase()).toMatch(/violation|violat/i);
+  });
+
+  it("note references r039 when coordinated move condition met", () => {
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 57);
+    expect(note).toContain("r039");
+  });
+
+  it("note references r040 when confidence ≥60", () => {
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 67);
+    expect(note).toContain("r040");
+  });
+
+  it("note includes the confidence value", () => {
+    const note = buildR039R040CrossAssetNote(multiClassSnaps, 67);
+    expect(note).toContain("67%");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `buildR039R040CrossAssetNote(snapshots, confidence)` to `oracle.ts`
- Injected into ORACLE-SETUPS prompt (after `r029Note`) so ORACLE sees the requirement before committing to setup construction
- Triggers on **r039** (confidence ≥55% + 3+ asset classes moving >2%) or **r040** (confidence ≥60%)
- Note names all four asset classes (forex, indices, crypto, commodities), requires ≥2 covered, flags only-forex sessions as a RULE VIOLATION
- Not injected for weekend crypto-only sessions

## Why

Sessions #181–#183 at 67% confidence produced only EUR/USD + EUR/JPY setups while NASDAQ (+4.65%), BTC (+5.15%), and Oil (−7.87%) were all active. The post-hoc `validateOracleOutput` warnings for r039/r040 were insufficient — ORACLE had already committed to forex-only by the time validation ran. Pre-construction injection (same pattern as `buildR041ScreeningNote` for r041) is the only reliable fix.

## Test plan

- [ ] `npm test` — 586 tests pass (10 new oracle tests for `buildR039R040CrossAssetNote`)
- [ ] `npm run build` — clean TypeScript compile
- [ ] Run session after merge: at ≥57% confidence with multi-class moves, expect setups across forex + at least one other class