### PR TITLE
fix(oracle): code-reclassify 'Other' setup types to correct ICT patterns

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -489,6 +489,10 @@ Only respond with the JSON array, no other text.`;
     console.warn(`  \u26a0 ${rawSetups.length - validSetups.length} setup(s) dropped — see warnings above`);
   }
 
+  // Reclassify "Other" setup types to the correct ICT pattern based on description keywords.
+  // Code enforcement backup for ORACLE's tendency to use "Other" as a default catch-all.
+  const reclassifiedSetups = reclassifyOtherSetups(validSetups);
+
   // Fix undefined bias notes
   if (parsed.bias) {
     if (!parsed.bias.notes || parsed.bias.notes === "undefined" || parsed.bias.notes.trim() === "") {
@@ -509,7 +513,7 @@ Only respond with the JSON array, no other text.`;
   // r039/r040 code enforcement: penalize confidence when setups cover only 1 asset class
   // despite multi-class market conditions. Backup to buildR039R040CrossAssetNote prompt injection.
   const { penalized: confAfterCrossAsset, reason: crossAssetReason } = applyR039R040Penalty(
-    finalConfidence, snapshots, validSetups, isWeekend
+    finalConfidence, snapshots, reclassifiedSetups, isWeekend
   );
   if (crossAssetReason) {
     console.warn(`  ⚠ ORACLE ${crossAssetReason}`);
@@ -525,7 +529,7 @@ Only respond with the JSON array, no other text.`;
     sessionId,
     marketSnapshots: snapshots,
     analysis:        finalAnalysis,
-    setups:          validSetups,
+    setups:          reclassifiedSetups,
     bias:            parsed.bias           ?? { overall: "neutral", notes: "" },
     keyLevels:       [...(parsed.keyLevels ?? []), ...screeningKeyLevels],
     confidence:      finalConfidence,
@@ -785,6 +789,36 @@ export function enforceR041ScreeningValidation(
   const injected = `Screening validation: ${parts.join(", ")}`;
   console.warn(`  ⚠ ORACLE r041: screening validation missing at ${confidence}% confidence — auto-injected`);
   return `${analysis}\n${injected}`;
+}
+
+// ── ICT setup type reclassifier ───────────────────────────
+// Code enforcement: when ORACLE types a setup as "Other", attempt to reclassify
+// it to the correct ICT pattern by matching keywords in the description.
+// Priority: specific patterns (FVG, OB, CISD, PDH/PDL, Liquidity Sweep) before
+// MSS (which is the broadest structure-based catch-all).
+// Root cause of sessions #176-#177, #185: ORACLE uses "Other" as default instead
+// of selecting the matching ICT label from the prompt schema.
+export function reclassifyOtherSetups(setups: any[]): any[] {
+  const rules: Array<{ type: string; patterns: RegExp }> = [
+    { type: "FVG",            patterns: /fair\s+value\s+gap|fvg\b|imbalance/i },
+    { type: "OB",             patterns: /order\s+block|\bob\b|mitigation\s+block|institutional\s+(level|order)/i },
+    { type: "CISD",           patterns: /\bcisd\b|change\s+in\s+state\s+of\s+delivery|displacement\s+candle/i },
+    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low/i },
+    { type: "Liquidity Sweep",patterns: /liquidity\s+sweep|stop\s+hunt|liquidity\s+grab|equal\s+highs|equal\s+lows|sell.?side\s+liquidity|buy.?side\s+liquidity/i },
+    { type: "MSS",            patterns: /market\s+structure\s+shift|structure\s+(break|shift)|structural\s+break|\bmss\b|\bmomentum\b|breakout|breaking\s+(above|below)|break\s+(above|below)/i },
+  ];
+
+  return setups.map(setup => {
+    if (setup.type !== "Other") return setup;
+    const desc = (setup.description ?? "").toLowerCase();
+    for (const rule of rules) {
+      if (rule.patterns.test(desc)) {
+        console.warn(`  ⚠ Setup reclassifier: "${setup.instrument}" Other → ${rule.type} (matched description keywords)`);
+        return { ...setup, type: rule.type };
+      }
+    }
+    return setup;
+  });
 }
 
 // ── r041 screening validation enforcement ─────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote, applyR039R040Penalty, enforceR041ScreeningValidation } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote, applyR039R040Penalty, enforceR041ScreeningValidation, reclassifyOtherSetups } from "../src/oracle";
 import { resolveConfidence } from "../src/validate";
 import type { MarketSnapshot } from "../src/types";
 
@@ -1432,5 +1432,104 @@ describe("enforceR041ScreeningValidation", () => {
     expect(result).toMatch(/ETH|Ethereum/i);
     expect(result).toMatch(/Gold/i);
     expect(result).toMatch(/Oil/i);
+  });
+});
+
+// ── reclassifyOtherSetups ─────────────────────────────────
+// Code enforcement: when ORACLE types a setup as "Other", reclassify it
+// based on description keywords to the correct ICT pattern type.
+// Root cause of sessions #176-#177, #185: ORACLE defaults to "Other" as
+// a catch-all rather than selecting the matching ICT label.
+
+describe("reclassifyOtherSetups", () => {
+  function makeSetup(description: string, type = "Other", instrument = "EUR/USD") {
+    return { instrument, type, description, direction: "bullish", entry: 1.18, stop: 1.175, target: 1.19 };
+  }
+
+  it("reclassifies 'Other' with momentum/structure break keywords to MSS", () => {
+    const result = reclassifyOtherSetups([makeSetup("Strong momentum continuation above 1.1786, targeting 1.185 resistance")]);
+    expect(result[0].type).toBe("MSS");
+  });
+
+  it("reclassifies 'Other' with 'market structure shift' to MSS", () => {
+    const result = reclassifyOtherSetups([makeSetup("Market structure shift confirmed above 1.178 resistance level")]);
+    expect(result[0].type).toBe("MSS");
+  });
+
+  it("reclassifies 'Other' with 'breakout' to MSS", () => {
+    const result = reclassifyOtherSetups([makeSetup("Breakout above 26000 psychological resistance with volume confirmation")]);
+    expect(result[0].type).toBe("MSS");
+  });
+
+  it("reclassifies 'Other' with 'liquidity sweep' to Liquidity Sweep", () => {
+    const result = reclassifyOtherSetups([makeSetup("Liquidity sweep above equal highs at 1.185 before reversal")]);
+    expect(result[0].type).toBe("Liquidity Sweep");
+  });
+
+  it("reclassifies 'Other' with 'stop hunt' to Liquidity Sweep", () => {
+    const result = reclassifyOtherSetups([makeSetup("Stop hunt above session high clearing sell-side liquidity")]);
+    expect(result[0].type).toBe("Liquidity Sweep");
+  });
+
+  it("reclassifies 'Other' with 'fair value gap' to FVG", () => {
+    const result = reclassifyOtherSetups([makeSetup("Fair value gap fill opportunity from 1.175-1.178 imbalance zone")]);
+    expect(result[0].type).toBe("FVG");
+  });
+
+  it("reclassifies 'Other' with 'order block' to OB", () => {
+    const result = reclassifyOtherSetups([makeSetup("Bullish order block mitigation at 1.175 institutional level")]);
+    expect(result[0].type).toBe("OB");
+  });
+
+  it("reclassifies 'Other' with 'PDH' to PDH/PDL", () => {
+    const result = reclassifyOtherSetups([makeSetup("Break above PDH at 1.182 with continuation potential")]);
+    expect(result[0].type).toBe("PDH/PDL");
+  });
+
+  it("reclassifies 'Other' with 'previous day high' to PDH/PDL", () => {
+    const result = reclassifyOtherSetups([makeSetup("Rejection from previous day high creating bearish setup")]);
+    expect(result[0].type).toBe("PDH/PDL");
+  });
+
+  it("reclassifies 'Other' with 'CISD' to CISD", () => {
+    const result = reclassifyOtherSetups([makeSetup("CISD confirmed at 1.176 after displacement candle through support")]);
+    expect(result[0].type).toBe("CISD");
+  });
+
+  it("leaves 'Other' unchanged when no ICT keywords match", () => {
+    const result = reclassifyOtherSetups([makeSetup("Price near key level with potential for continuation")]);
+    expect(result[0].type).toBe("Other");
+  });
+
+  it("does not change already-classified setups", () => {
+    const setup = makeSetup("Market structure shift above resistance", "MSS");
+    const result = reclassifyOtherSetups([setup]);
+    expect(result[0].type).toBe("MSS");
+  });
+
+  it("processes mixed arrays — only reclassifies Other entries", () => {
+    const setups = [
+      makeSetup("Liquidity sweep at session highs", "Other"),
+      makeSetup("Fair value gap fill", "FVG"),
+      makeSetup("Order block mitigation zone", "Other"),
+    ];
+    const result = reclassifyOtherSetups(setups);
+    expect(result[0].type).toBe("Liquidity Sweep");
+    expect(result[1].type).toBe("FVG"); // unchanged
+    expect(result[2].type).toBe("OB");
+  });
+
+  it("handles empty array", () => {
+    expect(reclassifyOtherSetups([])).toEqual([]);
+  });
+
+  it("session #185 EUR/USD description reclassifies to MSS", () => {
+    const desc = "Strong USD weakness theme driving momentum above 1.1786, targeting psychological 1.1850 resistance";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("MSS");
+  });
+
+  it("session #185 Bitcoin description reclassifies to MSS", () => {
+    const desc = "Strong crypto momentum continuation above 75345, targeting 76000 ATH resistance";
+    expect(reclassifyOtherSetups([makeSetup(desc, "Other", "Bitcoin")])[0].type).toBe("MSS");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `reclassifyOtherSetups(setups)` to `oracle.ts`
- When ORACLE labels a setup as `"Other"`, inspects the description for ICT pattern keywords and reclassifies to the correct type
- Priority order: FVG → OB → CISD → PDH/PDL → Liquidity Sweep → MSS (specific before broad)
- Wired into `runOracleAnalysis` after `validSetups` filter, before confidence computation

## Classification rules

| Type | Keywords matched |
|------|-----------------|
| FVG | fair value gap, fvg, imbalance |
| OB | order block, ob, mitigation block, institutional level/order |
| CISD | cisd, change in state of delivery, displacement candle |
| PDH/PDL | pdh, pdl, previous day high/low, prior day high/low |
| Liquidity Sweep | liquidity sweep, stop hunt, liquidity grab, equal highs/lows, sell/buy-side liquidity |
| MSS | market structure shift, structure break/shift, mss, momentum, breakout, break above/below |

## Why

Sessions #176–#177 and #185: ORACLE typed all setups as `"Other"` despite clear ICT patterns in descriptions (momentum continuation, structure breaks, liquidity sweeps). AXIOM called it out in #185: *"All setups labeled 'Other' despite clear structure breaks and liquidity interactions."* Prompt-based instructions ("use FVG/OB/MSS not Other") have been in the RULES section for sessions and ORACLE ignores them. Code reclassification is the only reliable fix.

## Test plan

- [ ] `npm test` — 623 tests pass (16 new reclassifier tests)
- [ ] `npm run build` — clean TypeScript compile
- [ ] Run session: expect setup types to show FVG/OB/MSS/Liquidity Sweep instead of Other