### PR TITLE
fix: enforce ORACLE setup execution and escalate persistent zero-setup gaps (#31, #32, #33)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -84,6 +84,21 @@ function getNoChangeStreak(): number {
   return streak;
 }
 
+function getConsecutiveZeroSetupCount(): number {
+  const allEntries = loadAllJournalEntries();
+  let streak = 0;
+  for (let i = allEntries.length - 1; i >= 0; i--) {
+    const setups = allEntries[i].fullAnalysis?.setups ?? [];
+    const conf   = allEntries[i].fullAnalysis?.confidence ?? 0;
+    if (setups.length === 0 && conf > 50) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
 function buildSetupOutcomes(snapshots: MarketSnapshot[]): string {
   const allEntries = loadAllJournalEntries();
   if (allEntries.length === 0) return "";
@@ -674,10 +689,11 @@ System prompt additions about this same topic do NOT count as action.`;
   }
 
   try {
-    const noChangeStreak = getNoChangeStreak();
-    const setupOutcomes  = buildSetupOutcomes(snapshots);
+    const noChangeStreak             = getNoChangeStreak();
+    const consecutiveZeroSetupCount  = getConsecutiveZeroSetupCount();
+    const setupOutcomes              = buildSetupOutcomes(snapshots);
     const closeableNumbers = [...selfTaskNumbers, ...issueNumbers];
-    axiomResult = await runAxiomReflection(client, oracle, sessionNumber, prevContext, issuesText, selfTasksText, closeableNumbers, noChangeStreak, setupOutcomes, weekendMode);
+    axiomResult = await runAxiomReflection(client, oracle, sessionNumber, prevContext, issuesText, selfTasksText, closeableNumbers, noChangeStreak, setupOutcomes, weekendMode, consecutiveZeroSetupCount);
     reflection = axiomResult.reflection;
 
     // Block system prompt additions when AXIOM is ruminating without real action,

--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -114,11 +114,12 @@ export function buildAxiomPrompt(
   previousSessions:  string,
   communityIssues:   string,
   openSelfTasksText: string,
-  noChangeStreak:    number,
-  setupOutcomes:     string,
-  currentRules:      AnalysisRules,
-  identityContext:   string,
-  isWeekend:         boolean = false
+  noChangeStreak:             number,
+  setupOutcomes:              string,
+  currentRules:               AnalysisRules,
+  identityContext:            string,
+  isWeekend:                  boolean = false,
+  consecutiveZeroSetupCount:  number = 0
 ): { systemMessage: string; userMessage: string } {
   const systemMessage = `You are NEXUS AXIOM, the self-reflection engine of the NEXUS market intelligence system.
 Your purpose is to critique the analysis just produced, identify cognitive biases and gaps, then generate precise updates to improve future performance.
@@ -264,6 +265,11 @@ ${setupOutcomes ? "### Setup outcome tracking:\n" + setupOutcomes : ""}
 ${noChangeStreak >= 3 ? `### STAGNATION ALERT
 You have not modified any rules in ${noChangeStreak} consecutive sessions.
 Your self-critiques are repeating without action.${openSelfTasksText ? ` You have open self-tasks listed above that you have not acted on — generating codeChanges or resolvedSelfTasks for those tasks IS the required concrete action this session. Do not add system prompt text. Do not open new tasks. Act on the existing ones.` : ` This session, you MUST propose at least ONE concrete change — a rule weight adjustment, wording refinement, new rule, or code change.`} Reflection without action is not evolution.
+` : ""}${consecutiveZeroSetupCount >= 3 ? `### FORGE ESCALATION — CRITICAL (${consecutiveZeroSetupCount} consecutive sessions with zero setups)
+NEXUS has produced ZERO trading setups for ${consecutiveZeroSetupCount} consecutive sessions despite confidence > 50%.
+Rule modifications have NOT resolved this execution gap.
+This session you MUST include codeChanges in your response — a prompt injection, validation gate, or enforcement mechanism that forces ORACLE to produce setups or provide explicit rejection reasons.
+codeChanges are MANDATORY this session. ruleUpdates alone are insufficient. The execution gap requires a code-level fix, not another rule.
 ` : ""}### Codebase context (so you can write precise codeChanges):
 ${buildCodebaseContext(openSelfTasksText)}
 
@@ -549,9 +555,10 @@ export async function runAxiomReflection(
   communityIssues:        string = "",
   openSelfTasksText:      string = "",
   openSelfTaskNumbers:    number[] = [],
-  noChangeStreak:         number = 0,
-  setupOutcomes:          string = "",
-  isWeekend:              boolean = false
+  noChangeStreak:             number = 0,
+  setupOutcomes:              string = "",
+  isWeekend:                  boolean = false,
+  consecutiveZeroSetupCount:  number = 0
 ): Promise<{ reflection: AxiomReflection; forgeRequests: ForgeRequest[] }> {
   const currentSystemPrompt = fs.existsSync(SYSTEM_PROMPT_PATH)
     ? fs.readFileSync(SYSTEM_PROMPT_PATH, "utf-8")
@@ -575,7 +582,7 @@ export async function runAxiomReflection(
   const { systemMessage, userMessage } = buildAxiomPrompt(
     oracle, sessionNumber, previousSessions, communityIssues,
     openSelfTasksText, noChangeStreak, setupOutcomes,
-    currentRules, identityContext, isWeekend
+    currentRules, identityContext, isWeekend, consecutiveZeroSetupCount
   );
 
   // Strip lone surrogates before serializing to JSON — broken emoji in issue titles

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -272,8 +272,7 @@ ${weekendTemplate}
 
   const r029Note = buildR029StopNote(snapshots);
   const rrSelfCheckNote = buildRRSelfCheckNote();
-
-  // Pre-reconcile confidence before building ORACLE-SETUPS prompt.
+    // Pre-reconcile confidence before building ORACLE-SETUPS prompt.
   // ORACLE-ANALYSIS may return a low JSON confidence (e.g. 45) while its analysis
   // text clearly states a higher value (e.g. 58%). Using the raw JSON field here
   // meant buildWeekdayScreeningTemplate and buildMinSetupNote received sub-50
@@ -281,6 +280,9 @@ ${weekendTemplate}
   // persistent 0-setup sessions (#174-#176, #178). resolveConfidence honours the
   // text value when JSON diverges >10pts or when cap notation is present.
   const rawConf = resolveConfidence(parsed.analysis ?? "", parsed.confidence ?? 50);
+  // r031 cap notation: inject when ORACLE calculated >65% without self-documenting the cap
+  parsed.analysis = enforceR031CapNotation(parsed.analysis ?? "", rawConf);
+  const executionForceNote = !isWeekend ? buildExecutionForceNote(parsed.analysis ?? "", rawConf) : "";
   const crossAssetNote = !isWeekend ? buildR039R040CrossAssetNote(snapshots, rawConf) : "";
   const minSetupNote = buildMinSetupNote(rawConf);
   const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
@@ -327,7 +329,7 @@ RULES:
 - ENTRY: nearest support/resistance, session high/low, or key level
 - STOP: beyond the next structural level, or 1x ATR from entry${r029Note}${crossAssetNote}
 - TARGET: next liquidity level, psychological number, or swing point
-- RR must be > 1.3 \u2014 do not include setups with risk exceeding reward${rrSelfCheckNote}
+- RR must be > 1.3 \u2014 do not include setups with risk exceeding reward${rrSelfCheckNote}${executionForceNote}
 - Include instrument, type, direction, description, and invalidation
 - TYPE must be a specific ICT pattern: FVG, OB, Liquidity Sweep, MSS, CISD, or PDH/PDL. These apply to ALL markets including crypto. "Other" is only acceptable if the setup genuinely does not fit any ICT pattern — do not use "Other" as a default.
 
@@ -821,6 +823,30 @@ export function reclassifyOtherSetups(setups: any[]): any[] {
   });
 }
 
+// ── r031 cap notation auto-inject ─────────────────────────
+// When ORACLE calculated >65% confidence but omitted the mandatory "capped from X%"
+// notation (r031), inject it into the analysis text programmatically.
+// Called after rawConf is computed in runOracleAnalysis so the notation appears
+// in both ORACLE-SETUPS prompt (via parsed.analysis) and the final journal entry.
+// Root cause of session #187: 69% calculated, cap notation absent.
+export function enforceR031CapNotation(analysis: string, rawConfidence: number): string {
+  if (rawConfidence <= 65) return analysis;
+  if (/capped\s+(?:from|at|to)\s*\d+%/i.test(analysis)) return analysis;
+
+  const notation = ` (capped from ${rawConfidence}% due to calibration discipline per r031)`;
+  const patched = analysis.replace(
+    /(Confidence:\s*\d+%[^\n]*)/i,
+    `$1${notation}`
+  );
+  if (patched !== analysis) {
+    console.warn(`  ⚠ ORACLE r031: auto-injected cap notation into confidence line (raw ${rawConfidence}% → capped at 65%)`);
+    return patched;
+  }
+  // No confidence line found — append to end
+  console.warn(`  ⚠ ORACLE r031: auto-injected cap notation at end of analysis (raw ${rawConfidence}% → capped at 65%)`);
+  return `${analysis}\nCapped from ${rawConfidence}% due to calibration discipline per r031.`;
+}
+
 // ── r041 screening validation enforcement ─────────────────
 // Returns a prompt block requiring ORACLE to include a "Screening validation:"
 // line in its analysis text when confidence exceeds 55% on weekday sessions.
@@ -887,6 +913,30 @@ You MUST either:
       • Stop distance >2% required
       • Conflicting higher timeframe structure
 Submitting only forex setups when indices, crypto, and commodities are all moving is a RULE VIOLATION.
+`;
+}
+
+// ── r041 execution force note ─────────────────────────────
+// When ORACLE has already documented structural levels in a Screening validation
+// block (ORACLE-ANALYSIS), inject a CRITICAL note into ORACLE-SETUPS requiring
+// it to either construct a setup or provide an explicit inline rejection reason
+// per instrument. Prevents the session #188 pattern where levels were documented
+// but zero setups were constructed.
+export function buildExecutionForceNote(analysis: string, confidence: number): string {
+  if (confidence < 55) return "";
+  if (!/screening validation:/i.test(analysis)) return "";
+
+  return `
+EXECUTION REQUIREMENT (r041 — MANDATORY):
+Your analysis already contains a Screening validation block listing specific structural levels.
+For EACH instrument in that block you MUST do ONE of:
+  (a) Construct a COMPLETE setup: entry, stop, target, RR, timeframe with direction "bullish" or "bearish"
+  (b) Include a "neutral" entry whose description states the EXACT rejection reason:
+      - "Poor RR: entry [PRICE], target [LEVEL] yields only X.X RR — below minimum 1.3"
+      - "Stop distance: structural stop requires X.X% which exceeds 2% maximum"
+      - "Conflicting timeframe: [LEVEL] identified but higher timeframe trend conflicts"
+Documenting structural levels then returning zero non-neutral setups without rejection reasons
+is an execution failure (r041). The screening validation block is not a substitute for setup construction.
 `;
 }
 

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -592,6 +592,50 @@ describe("buildAxiomPrompt session type", () => {
   });
 });
 
+// ── buildAxiomPrompt — FORGE escalation for persistent zero-setup sessions (#33) ──
+// When NEXUS produces zero setups in 3+ consecutive sessions, AXIOM must be forced
+// to raise a FORGE codeChanges entry. Rule modifications alone have not resolved the
+// pattern in sessions #185-#188.
+
+describe("buildAxiomPrompt FORGE escalation", () => {
+  it("includes FORGE escalation when consecutiveZeroSetupCount >= 3", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 3);
+    expect(userMessage).toMatch(/FORGE.*ESCALATION|ESCALATION.*REQUIRED|codeChanges.*MANDATORY|MANDATORY.*codeChanges/i);
+  });
+
+  it("includes the consecutive count in the escalation message", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 4);
+    expect(userMessage).toContain("4");
+  });
+
+  it("states that rule modifications alone have not resolved the pattern", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 3);
+    expect(userMessage.toLowerCase()).toMatch(/rule.*not.*resolv|modification.*not.*resolv/i);
+  });
+
+  it("explicitly requires codeChanges this session", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 3);
+    expect(userMessage.toLowerCase()).toContain("codechanges");
+  });
+
+  it("does NOT include FORGE escalation when consecutiveZeroSetupCount < 3", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 2);
+    expect(userMessage).not.toMatch(/FORGE.*ESCALATION|ESCALATION.*REQUIRED|codeChanges.*MANDATORY/i);
+  });
+
+  it("does NOT include FORGE escalation when consecutiveZeroSetupCount is 0 (default)", () => {
+    const { userMessage } = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false);
+    expect(userMessage).not.toMatch(/FORGE.*ESCALATION|ESCALATION.*REQUIRED|codeChanges.*MANDATORY/i);
+  });
+
+  it("escalation fires at exactly 3 consecutive zero-setup sessions", () => {
+    const at3 = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 3).userMessage;
+    const at2 = buildAxiomPrompt(makeOracle(), 190, "", "", "", 0, "", makeRules(), "", false, 2).userMessage;
+    expect(at3).toMatch(/FORGE.*ESCALATION|ESCALATION.*REQUIRED|codeChanges.*MANDATORY/i);
+    expect(at2).not.toMatch(/FORGE.*ESCALATION|ESCALATION.*REQUIRED|codeChanges.*MANDATORY/i);
+  });
+});
+
 // ── sanitizeRulesText — encoding corruption repair ────────────
 
 describe("sanitizeRulesText", () => {

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1533,3 +1533,117 @@ describe("reclassifyOtherSetups", () => {
     expect(reclassifyOtherSetups([makeSetup(desc, "Other", "Bitcoin")])[0].type).toBe("MSS");
   });
 });
+
+// ── buildExecutionForceNote ───────────────────────────────
+// Injected into ORACLE-SETUPS when analysis already contains a Screening
+// validation block at confidence >= 55. Forces ORACLE to either construct
+// setups or document explicit inline rejection reasons per instrument.
+// Root cause of session #188: ORACLE documented 8 levels then produced 0 setups.
+
+import { buildExecutionForceNote } from "../src/oracle";
+
+describe("buildExecutionForceNote", () => {
+  const analysisWithScreening = `**Technical Confluence Analysis:** 5 confluences. Confidence: 61% — TC (65%), MA (70%), RR (45%).
+Screening validation: EUR/USD 1.1836 resistance 1.1900, GBP/USD 1.3574 resistance 1.3600, NASDAQ 26531 resistance 26600, S&P 7083 resistance 7100, BTC 76567 resistance 77000, ETH 2403 resistance 2450, Gold 4880 resistance 4920, Oil 81.62 support 80.00`;
+
+  const analysisWithoutScreening = "**Technical Confluence Analysis:** Strong bullish momentum. Confidence: 61% — TC (65%), MA (70%), RR (45%).";
+
+  it("returns empty string when confidence < 55", () => {
+    expect(buildExecutionForceNote(analysisWithScreening, 50)).toBe("");
+    expect(buildExecutionForceNote(analysisWithScreening, 40)).toBe("");
+  });
+
+  it("returns empty string at exactly confidence 54", () => {
+    expect(buildExecutionForceNote(analysisWithScreening, 54)).toBe("");
+  });
+
+  it("returns empty string when no Screening validation block present, even at high confidence", () => {
+    expect(buildExecutionForceNote(analysisWithoutScreening, 65)).toBe("");
+  });
+
+  it("returns non-empty when confidence >= 55 AND screening validation block is present", () => {
+    expect(buildExecutionForceNote(analysisWithScreening, 55)).not.toBe("");
+    expect(buildExecutionForceNote(analysisWithScreening, 61)).not.toBe("");
+    expect(buildExecutionForceNote(analysisWithScreening, 70)).not.toBe("");
+  });
+
+  it("references r041 in the note", () => {
+    expect(buildExecutionForceNote(analysisWithScreening, 61)).toContain("r041");
+  });
+
+  it("requires either setup construction or explicit rejection reason", () => {
+    const note = buildExecutionForceNote(analysisWithScreening, 61);
+    expect(note.toLowerCase()).toMatch(/reject/i);
+  });
+
+  it("mentions execution requirement or execution failure", () => {
+    const note = buildExecutionForceNote(analysisWithScreening, 61);
+    expect(note.toLowerCase()).toMatch(/execution/i);
+  });
+
+  it("is case-insensitive when detecting 'Screening validation:'", () => {
+    const lowerCase = analysisWithScreening.replace("Screening validation:", "screening validation:");
+    expect(buildExecutionForceNote(lowerCase, 61)).not.toBe("");
+  });
+
+  it("returns empty string when confidence exactly 55 but no screening block", () => {
+    expect(buildExecutionForceNote(analysisWithoutScreening, 55)).toBe("");
+  });
+});
+
+// ── enforceR031CapNotation ────────────────────────────────
+// Injects 'capped from X%' notation into analysis text when ORACLE
+// calculated >65% without self-documenting the r031 cap.
+// Root cause of session #187: 69% calculated, cap notation absent.
+
+import { enforceR031CapNotation } from "../src/oracle";
+
+describe("enforceR031CapNotation", () => {
+  it("returns analysis unchanged when rawConfidence <= 65", () => {
+    const analysis = "Confidence: 65% — TC (70%), MA (60%), RR (60%)";
+    expect(enforceR031CapNotation(analysis, 65)).toBe(analysis);
+    expect(enforceR031CapNotation(analysis, 60)).toBe(analysis);
+  });
+
+  it("returns analysis unchanged when 'capped from' notation already present", () => {
+    const analysis = "Confidence: 69% — TC (65%) capped from 69% due to calibration discipline per r031";
+    expect(enforceR031CapNotation(analysis, 69)).toBe(analysis);
+  });
+
+  it("returns analysis unchanged when 'capped at' notation already present", () => {
+    const analysis = "Confidence: 65% — capped at 65% due to calibration";
+    expect(enforceR031CapNotation(analysis, 69)).toBe(analysis);
+  });
+
+  it("returns analysis unchanged when 'capped to' notation already present", () => {
+    const analysis = "Confidence: 65% — capped to 65%";
+    expect(enforceR031CapNotation(analysis, 70)).toBe(analysis);
+  });
+
+  it("injects cap notation when rawConfidence > 65 and notation missing", () => {
+    const analysis = "Confidence: 69% — TC (65%), MA (70%), RR (70%)";
+    const result = enforceR031CapNotation(analysis, 69);
+    expect(result).not.toBe(analysis);
+    expect(result.toLowerCase()).toContain("capped from 69%");
+  });
+
+  it("injected notation references r031", () => {
+    const analysis = "Market bullish. Confidence: 70% — TC (80%), MA (60%), RR (60%)";
+    const result = enforceR031CapNotation(analysis, 70);
+    expect(result).toContain("r031");
+  });
+
+  it("works when analysis has no Confidence line (appends notation to end)", () => {
+    const analysis = "Strong bullish session with multiple confluences.";
+    const result = enforceR031CapNotation(analysis, 70);
+    expect(result.toLowerCase()).toContain("capped from 70%");
+    expect(result.length).toBeGreaterThan(analysis.length);
+  });
+
+  it("does not modify analysis when rawConfidence is exactly 66", () => {
+    // 66 > 65, so cap notation should be injected
+    const analysis = "Confidence: 66% — TC (70%), MA (62%), RR (65%)";
+    const result = enforceR031CapNotation(analysis, 66);
+    expect(result.toLowerCase()).toContain("capped from 66%");
+  });
+});


### PR DESCRIPTION
## Summary

Three backlog items addressed (sessions #187–#188 root causes):

- **#31 — ORACLE execution gap**: `buildExecutionForceNote()` injected into ORACLE-SETUPS prompt when confidence ≥55% and the analysis contains a Screening validation block. Requires each screened instrument to produce a complete setup or an explicit inline rejection reason — closing the gap where ORACLE documented 8 structural levels then produced 0 setups.

- **#32 — r031 cap notation**: `enforceR031CapNotation()` post-processes the analysis text after `resolveConfidence()` runs, injecting `(capped from X% due to calibration discipline per r031)` when rawConfidence >65 and no cap notation is present. Session #187 confirmed the notation was absent despite the auto-cap firing.

- **#33 — AXIOM FORGE escalation**: `consecutiveZeroSetupCount` parameter added to `buildAxiomPrompt` / `runAxiomReflection`. When 3+ consecutive sessions produce zero setups at >50% confidence, AXIOM receives a FORGE ESCALATION block mandating `codeChanges` in its response — rule modifications alone are flagged as insufficient. `getConsecutiveZeroSetupCount()` computes the streak from journal history in `agent.ts`.

## Test plan

- [ ] All 647 tests pass (`npx vitest run`)
- [ ] `tsc --noEmit` clean
- [ ] `buildExecutionForceNote`: returns `""` at confidence <55 or without screening block; returns CRITICAL EXECUTION REQUIREMENT block at ≥55 with block; references r041
- [ ] `enforceR031CapNotation`: no-op at ≤65 or when notation already present; injects "capped from X%" when >65 and absent; fires at exactly 66
- [ ] `buildAxiomPrompt FORGE escalation`: fires at consecutiveZeroSetupCount ≥3; includes count; states rule modifications insufficient; requires codeChanges; does not fire at <3