### PR TITLE
fix(validate): fix r029 false-positive stop warnings — per-instrument instead of session-wide

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -310,21 +310,31 @@ export function validateOracleOutput(
     }
   }
 
-  // Tight stop warning on extreme volatility days (r029 enforcement)
-  // If any snapshot moved ≥5%, stops <1% of entry are almost certainly
-  // too narrow to survive normal noise on that instrument.
-  const extremeDay = oracle.marketSnapshots?.some(s => Math.abs(s.changePercent) >= 3);
-  if (extremeDay && oracle.setups) {
+  // Tight stop warning — per-instrument r029 enforcement (warn-only layer).
+  // Only warns when THAT INSTRUMENT's own session move ≥3% and stop <1% of entry.
+  // A session where Oil moves 8% does NOT trigger warnings on EUR/USD setups.
+  if (oracle.marketSnapshots && oracle.setups) {
+    const instrVolMap = new Map<string, number>();
+    for (const snap of oracle.marketSnapshots) {
+      const move = Math.abs(snap.changePercent ?? 0);
+      instrVolMap.set(snap.name.toLowerCase(), move);
+      instrVolMap.set(snap.symbol.toLowerCase().replace(/[^a-z0-9]/g, ""), move);
+    }
     for (const s of oracle.setups) {
       if (
         typeof s.entry === "number" && s.entry > 0 &&
         typeof s.stop  === "number" && s.stop  > 0
       ) {
-        const stopPct = (Math.abs(s.entry - s.stop) / s.entry) * 100;
-        if (stopPct < 1) {
-          warnings.push(
-            `${s.instrument ?? "Setup"}: stop is only ${stopPct.toFixed(2)}% from entry during extreme volatility (≥5% session move) — r029 requires wider stops`
-          );
+        const instrKey     = (s.instrument ?? "").toLowerCase();
+        const instrKeyNorm = instrKey.replace(/[^a-z0-9]/g, "");
+        const instrMove    = instrVolMap.get(instrKey) ?? instrVolMap.get(instrKeyNorm) ?? 0;
+        if (instrMove >= 3) {
+          const stopPct = (Math.abs(s.entry - s.stop) / s.entry) * 100;
+          if (stopPct < 1) {
+            warnings.push(
+              `${s.instrument ?? "Setup"}: stop is only ${stopPct.toFixed(2)}% from entry during elevated volatility (instrument moved ${instrMove.toFixed(1)}%) — r029 requires wider stops`
+            );
+          }
         }
       }
     }

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -230,6 +230,83 @@ describe("validateOracleOutput", () => {
     expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(true);
   });
 
+  it("does NOT warn about tight stop on EUR/USD when only Oil moved 8% (false-positive regression)", () => {
+    // Bug: session-wide ≥3% trigger warned on ALL setups even when the setup's own
+    // instrument barely moved. Sessions #196-#200 hit this — EUR/USD (0.05% move),
+    // GBP/USD (0.54%), USD/CAD (0.89%) all got r029 warnings because Oil or indices moved big.
+    const oilSnapshot = {
+      symbol: "USOIL", name: "Crude Oil", category: "commodities",
+      price: 82.59, previousClose: 91.16, change: -8.57, changePercent: -9.40,
+      high: 91.20, low: 82.10, timestamp: new Date(),
+    };
+    const eurusdSnapshot = {
+      symbol: "EURUSD", name: "EUR/USD", category: "forex",
+      price: 1.1758, previousClose: 1.1752, change: 0.0006, changePercent: 0.05,
+      high: 1.1770, low: 1.1740, timestamp: new Date(),
+    };
+    const result = validateOracleOutput(
+      makeOracle({
+        marketSnapshots: [oilSnapshot, eurusdSnapshot],
+        setups: [{
+          instrument: "EUR/USD", type: "MSS", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 1.1758, stop: 1.1745, target: 1.1800, RR: 2.0, timeframe: "4H",
+          // stopPct ≈ 0.11% — tight, but EUR/USD itself only moved 0.05% (no r029 applies)
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(false);
+  });
+
+  it("does NOT warn about tight stop on GBP/USD (0.54% move) when NASDAQ moved 4.75%", () => {
+    const nasdaqSnapshot = {
+      symbol: "NAS100", name: "NASDAQ 100", category: "index",
+      price: 26672, previousClose: 25406, change: 1266, changePercent: 4.98,
+      high: 26700, low: 25400, timestamp: new Date(),
+    };
+    const gbpusdSnapshot = {
+      symbol: "GBPUSD", name: "GBP/USD", category: "forex",
+      price: 1.3502, previousClose: 1.3429, change: 0.0073, changePercent: 0.54,
+      high: 1.3545, low: 1.3420, timestamp: new Date(),
+    };
+    const result = validateOracleOutput(
+      makeOracle({
+        marketSnapshots: [nasdaqSnapshot, gbpusdSnapshot],
+        setups: [{
+          instrument: "GBP/USD", type: "OB", direction: "bearish",
+          description: "test", invalidation: "test",
+          entry: 1.3502, stop: 1.3520, target: 1.3450, RR: 2.9, timeframe: "4H",
+          // stopPct ≈ 0.13% — tight, but GBP/USD itself only moved 0.54% (no r029 applies)
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(false);
+  });
+
+  it("still warns on NASDAQ tight stop when NASDAQ itself moved 4.78%", () => {
+    // Regression: the per-instrument fix must not break the legitimate case
+    const nasdaqSnapshot = {
+      symbol: "NAS100", name: "NASDAQ 100", category: "index",
+      price: 25200, previousClose: 24050, change: 1150, changePercent: 4.78,
+      high: 25202, low: 24050, timestamp: new Date(),
+    };
+    const result = validateOracleOutput(
+      makeOracle({
+        marketSnapshots: [nasdaqSnapshot],
+        setups: [{
+          instrument: "NASDAQ 100", type: "PDH", direction: "bullish",
+          description: "test", invalidation: "test",
+          entry: 25200, stop: 25180, target: 25250, RR: 2.5, timeframe: "4H",
+          // stopPct ≈ 0.08% — NASDAQ itself moved 4.78%, so r029 warning is correct
+        }],
+      }),
+      []
+    );
+    expect(result.warnings.some((w) => w.includes("stop") && w.includes("volatility"))).toBe(true);
+  });
+
   it("does not warn about stop size when session moves are normal (<5%)", () => {
     const normalSnapshot = {
       symbol: "NAS100", name: "NASDAQ 100", category: "index",


### PR DESCRIPTION
## Problem

`validateOracleOutput` warned about tight stops using a session-wide trigger: if **any** instrument moved ≥3%, it flagged **all** setups in the session. Sessions #196–#200 hit this every run — EUR/USD (0.05% move), GBP/USD (0.54%), USD/CAD (0.89%) all received r029 warnings because Oil moved 8% or NASDAQ moved 4.98%.

The side effect: AXIOM added a system prompt directive in session #200 telling itself to **distrust its own validation layer**. That's the validation gate being undermined from the inside.

## Fix

Switch `validateOracleOutput`'s warn block to use the same per-instrument lookup pattern already correct in `filterNonCompliantSetups()` — only warn when **that instrument's own** session move ≥3%. Also corrects the misleading warning message text (said "≥5% session move" but threshold was actually ≥3%).

## Test plan

- [ ] 650/650 tests pass
- [ ] `tsc --noEmit` clean
- [ ] New test: EUR/USD tight stop + Oil 9.4% move → **no** r029 warning
- [ ] New test: GBP/USD tight stop + NASDAQ 4.98% move → **no** r029 warning  
- [ ] Regression: NASDAQ tight stop + NASDAQ 4.78% move → warning **still fires**