### PR TITLE
fix(oracle): expand reclassifyOtherSetups patterns to eliminate Other epidemic

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -805,8 +805,8 @@ export function reclassifyOtherSetups(setups: any[]): any[] {
     { type: "FVG",            patterns: /fair\s+value\s+gap|fvg\b|imbalance/i },
     { type: "OB",             patterns: /order\s+block|\bob\b|mitigation\s+block|institutional\s+(level|order)/i },
     { type: "CISD",           patterns: /\bcisd\b|change\s+in\s+state\s+of\s+delivery|displacement\s+candle/i },
-    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low/i },
-    { type: "Liquidity Sweep",patterns: /liquidity\s+sweep|stop\s+hunt|liquidity\s+grab|equal\s+highs|equal\s+lows|sell.?side\s+liquidity|buy.?side\s+liquidity/i },
+    { type: "Liquidity Sweep",patterns: /liquidity\s+sweep|stop\s+hunt|liquidity\s+grab|equal\s+highs|equal\s+lows|sell.?side\s+liquidity|buy.?side\s+liquidity|oversold.{0,100}(bounce|reversal|reversion|recovery)|(extreme|severe).{0,20}(decline|collapse|drop|fall).{0,60}(bounce|reversal)|(supply|demand)\s+shock.{0,20}(exhaustion|bounce|reversal)/i },
+    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low|session\s+(high|low)|psychological\s+(level|support|number)|(approaching|testing|rejection\s+from|rejecting)\s+.{0,30}(key\s+|major\s+|critical\s+|psychological\s+)?(resistance|support)|rejection\s+from\s+.{0,20}(high|low)\b|(resistance|support).{0,30}being\s+tested/i },
     { type: "MSS",            patterns: /market\s+structure\s+shift|structure\s+(break|shift)|structural\s+break|\bmss\b|\bmomentum\b|breakout|breaking\s+(above|below)|break\s+(above|below)/i },
   ];
 

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1532,6 +1532,60 @@ describe("reclassifyOtherSetups", () => {
     const desc = "Strong crypto momentum continuation above 75345, targeting 76000 ATH resistance";
     expect(reclassifyOtherSetups([makeSetup(desc, "Other", "Bitcoin")])[0].type).toBe("MSS");
   });
+
+  // ── Session #194-#200 regression: "Other" epidemic patterns ──
+  // These descriptions stayed "Other" across 5 sessions because the reclassifier
+  // lacked patterns for psychological levels, session highs, oversold bounces.
+
+  it("session #194 Bitcoin: psychological support → PDH/PDL", () => {
+    const desc = "Holding above 75000 psychological support despite session weakness, showing institutional accumulation zone strength";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #196 EUR/USD: rejection from session high → PDH/PDL", () => {
+    const desc = "Rejection from 1.18 high with consolidation near support suggests potential break lower on risk-off rotation";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #196 Gold: testing resistance → PDH/PDL", () => {
+    const desc = "Modest gain +0.28% with resistance at 4850 being tested. Safe-haven bid suggests continuation above resistance";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #198 NASDAQ: approaching key resistance → PDH/PDL", () => {
+    const desc = "Extreme rally +4.75% approaching resistance at 26700, risk-reward favors pullback from overextension";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #198 S&P: approaching key resistance → PDH/PDL", () => {
+    const desc = "Strong rally +3.24% approaching key resistance at 7150, overextended conditions suggest pullback";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #197 AUD/USD: targeting session high resistance → PDH/PDL", () => {
+    const desc = "Strong +0.94% rally on USD weakness, targeting 0.72 session high resistance";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #196 Oil: oversold conditions reversal from major support → Liquidity Sweep", () => {
+    const desc = "Severe decline -9.53% testing critical support at 80.00. Oversold conditions with geopolitical premium suggesting reversal potential from major support zone";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("Liquidity Sweep");
+  });
+
+  it("session #197 Oil: supply shock exhaustion bounce → Liquidity Sweep", () => {
+    const desc = "Supply shock exhaustion after -5.47% collapse, targeting 85.00 major support bounce";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("Liquidity Sweep");
+  });
+
+  it("session #198 Oil: extreme decline oversold bounce → Liquidity Sweep", () => {
+    const desc = "Extreme decline -5.31% testing psychological support at 85.00, oversold bounce expected";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("Liquidity Sweep");
+  });
+
+  it("session #200 USD/CAD: oversold reversion → Liquidity Sweep", () => {
+    const desc = "Oversold after -0.89% decline, approaching 1.364 support with USD weakness creating reversion opportunity";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("Liquidity Sweep");
+  });
 });
 
 // ── buildExecutionForceNote ───────────────────────────────


### PR DESCRIPTION
## Problem

Sessions #194–#200 had 81% of setups typed as "Other" (22/27) despite having clear ICT pattern descriptions. Root cause: `reclassifyOtherSetups()` had overly narrow patterns:

- **PDH/PDL** only matched `pdh`/`pdl`/`previous day high`/`previous day low` — missed session highs, psychological levels, and testing/approaching/rejection language
- **Liquidity Sweep** only matched explicit ICT terms (`liquidity sweep`, `stop hunt`, `equal highs`) — missed oversold bounces, extreme decline reversals, supply shock exhaustion

## Changes

**`src/oracle.ts` — `reclassifyOtherSetups()`:**
- Expanded **PDH/PDL** pattern: `session (high|low)`, `psychological (level|support|number)`, `approaching/testing/rejection from (key|major|critical) resistance/support`, `rejection from ... high/low`, `resistance/support being tested`
- Expanded **Liquidity Sweep** pattern: `oversold.{0,100}(bounce|reversal|reversion|recovery)`, `(extreme|severe) decline.{0,60} bounce/reversal`, `supply/demand shock exhaustion/bounce`
- Moved Liquidity Sweep **before** PDH/PDL in rule priority — descriptions combining "testing support" + "oversold bounce" (Oil, USD/CAD) now correctly classify as Liquidity Sweep

**`tests/oracle.test.ts`:**
- 10 regression tests covering exact descriptions from sessions #194–#200 that were incorrectly typed as "Other"

## Test Results

660/660 passing, `tsc --noEmit` clean. No regressions.