### PR TITLE
fix(forge): protect validate.ts from FORGE — exceeds 12k char limit

### DIFF
--- a/src/forge.ts
+++ b/src/forge.ts
@@ -59,6 +59,7 @@ const PROTECTED_FILES = new Set([
   "forge.ts",      // FORGE cannot rewrite itself
   "session.yml",   // self-modifying execution environment is too dangerous
   "README.md",     // documentation integrity — FORGE must not strip formatting
+  "validate.ts",   // 45k chars — exceeds FORGE's 12k limit; quality gates must be changed via developer PRs
 ]);
 
 // ── Filename prefixes FORGE can never modify ─────────────

--- a/tests/forge.test.ts
+++ b/tests/forge.test.ts
@@ -188,6 +188,13 @@ describe("PROTECTED_FILES", () => {
   it("contains README.md", () => {
     expect(PROTECTED_FILES.has("README.md")).toBe(true);
   });
+
+  it("contains validate.ts — too large for FORGE (45k chars) and quality-gate file", () => {
+    // validate.ts is 45,790 chars vs FORGE's 12,000-char limit.
+    // Protecting it makes failure immediate (no wasted API call) and prevents
+    // AXIOM from burning a FORGE slot on a file FORGE can never patch.
+    expect(PROTECTED_FILES.has("validate.ts")).toBe(true);
+  });
 });
 
 // ── PROTECTED_PREFIXES ──────────────────────────────────────


### PR DESCRIPTION
## Problem

`validate.ts` is 45,790 chars. FORGE's hard limit is 12,000 chars. Every time AXIOM requests a `validate.ts` patch via FORGE:

1. FORGE reads the file (I/O)
2. FORGE makes a Claude API call with the file content
3. FORGE returns `File too large for FORGE (45790 chars, max 12000)`
4. The FORGE slot is wasted

**Session #201 example:** AXIOM requested an r029 fix in validate.ts → FORGE burned the slot → 0 code changes that session.

## Fix

Add `validate.ts` to `PROTECTED_FILES`. The protection check runs before file read and API call, making rejection immediate with a clear message: `validate.ts is protected — FORGE cannot modify it`.

Changes to validate.ts must come through developer PRs (same as security.ts, forge.ts).

## Tests

1 new test: `PROTECTED_FILES.has("validate.ts")` → `true`

668/668 passing.

Closes backlog item #38.