### PR TITLE
fix(oracle): add 'near' to PDH/PDL reclassifier — catches price-support descriptions

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -806,7 +806,7 @@ export function reclassifyOtherSetups(setups: any[]): any[] {
     { type: "OB",             patterns: /order\s+block|\bob\b|mitigation\s+block|institutional\s+(level|order)/i },
     { type: "CISD",           patterns: /\bcisd\b|change\s+in\s+state\s+of\s+delivery|displacement\s+candle/i },
     { type: "Liquidity Sweep",patterns: /liquidity\s+sweep|stop\s+hunt|liquidity\s+grab|equal\s+highs|equal\s+lows|sell.?side\s+liquidity|buy.?side\s+liquidity|oversold.{0,100}(bounce|reversal|reversion|recovery)|(extreme|severe).{0,20}(decline|collapse|drop|fall).{0,60}(bounce|reversal)|(supply|demand)\s+shock.{0,20}(exhaustion|bounce|reversal)/i },
-    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low|session\s+(high|low)|psychological\s+(level|support|number)|(approaching|testing|rejection\s+from|rejecting)\s+.{0,30}(key\s+|major\s+|critical\s+|psychological\s+)?(resistance|support)|rejection\s+from\s+.{0,20}(high|low)\b|(resistance|support).{0,30}being\s+tested/i },
+    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low|session\s+(high|low)|psychological\s+(level|support|number)|(approaching|testing|near|rejection\s+from|rejecting)\s+.{0,30}(key\s+|major\s+|critical\s+|psychological\s+)?(resistance|support)|rejection\s+from\s+.{0,20}(high|low)\b|(resistance|support).{0,30}being\s+tested/i },
     { type: "MSS",            patterns: /market\s+structure\s+shift|structure\s+(break|shift)|structural\s+break|\bmss\b|\bmomentum\b|breakout|breaking\s+(above|below)|break\s+(above|below)/i },
   ];
 

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1586,6 +1586,17 @@ describe("reclassifyOtherSetups", () => {
     const desc = "Oversold after -0.89% decline, approaching 1.364 support with USD weakness creating reversion opportunity";
     expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("Liquidity Sweep");
   });
+
+  // ── Session #202 regressions: 'near' price support not caught ──
+  it("session #202 Bitcoin: near psychological price support → PDH/PDL", () => {
+    const desc = "BTC at 75616 near psychological 75000 support level. Defensive rotation within crypto showing relative strength versus altcoins. Targeting 77000 resistance.";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
+
+  it("session #202 Gold: near price support level → PDH/PDL", () => {
+    const desc = "Gold at 4728 near 4700 support level after -1.18% decline. Dollar weakness theme should support precious metals recovery targeting 4800 resistance.";
+    expect(reclassifyOtherSetups([makeSetup(desc)])[0].type).toBe("PDH/PDL");
+  });
 });
 
 // ── buildExecutionForceNote ───────────────────────────────


### PR DESCRIPTION
## Problem

Session #202: Bitcoin and Gold produced `Other` setups despite clear PDH/PDL descriptions:

- **Bitcoin**: *"BTC at 75616 near psychological 75000 support level..."*
- **Gold**: *"Gold at 4728 near 4700 support level after -1.18% decline..."*

The reclassifier's PDH/PDL pattern required `approaching|testing|rejection from|rejecting` before `resistance/support`. The word **"near"** wasn't in the set, so these descriptions fell through to `Other`.

## Fix

Add `near` to the keyword group in the PDH/PDL approaching pattern:

```
(approaching|testing|near|rejection from|rejecting) .{0,30} (key|major|critical|psychological)? (resistance|support)
```

**"near [price] support"** and **"near psychological [price] support"** now correctly classify as PDH/PDL.

## Tests

2 regression tests using exact descriptions from session #202. 670/670 passing.