### PR TITLE
fix(validate): >= 10 threshold in resolveConfidence catches exact 10pt divergence

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -106,7 +106,7 @@ export function resolveConfidence(analysis: string, jsonConfidence: number): num
   }
 
   const textConfidence = extractConfidenceFromText(analysis);
-  if (textConfidence !== null && Math.abs(textConfidence - jsonConfidence) > 10) {
+  if (textConfidence !== null && Math.abs(textConfidence - jsonConfidence) >= 10) {
     return textConfidence;
   }
   return jsonConfidence;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1178,10 +1178,16 @@ describe("resolveConfidence", () => {
     expect(resolveConfidence(analysis, 60)).toBe(60);
   });
 
-  it("returns JSON value when mismatch is exactly 10 points (boundary)", () => {
-    // diff == 10, not > 10, so return JSON
+  it("returns text value when mismatch is exactly 10 points (session #202 regression)", () => {
+    // Session #202: text=65%, JSON=55% — diff==10, should use text value (>= 10 threshold)
+    const analysis = "Confidence: 65% — TC (65%), MA (75%), RR (55%).";
+    expect(resolveConfidence(analysis, 55)).toBe(65);
+  });
+
+  it("returns text value when mismatch is exactly 10 points (boundary, high→low)", () => {
+    // diff == 10 exactly — must override JSON per >= 10 rule
     const analysis = "Confidence: 70%";
-    expect(resolveConfidence(analysis, 60)).toBe(60);
+    expect(resolveConfidence(analysis, 60)).toBe(70);
   });
 
   it("returns extracted value when mismatch is 11 points (just over boundary)", () => {


### PR DESCRIPTION
## Problem
Session #202 regression: ORACLE-ANALYSIS text stated **65% confidence**, JSON returned **55%** (divergence = exactly 10 pts). The old `> 10` guard excluded the boundary case, so `resolveConfidence` silently kept the JSON value (55%). This caused `buildMinSetupNote` to require 3 setups instead of 4, and ORACLE only produced 2.

## Fix
`src/validate.ts` line 109: change `> 10` → `>= 10`.

## Tests
Two new regression tests in `tests/validate.test.ts`:
- Session #202 exact scenario: text=65%, JSON=55% → now returns 65
- Boundary case: text=70%, JSON=60% → now returns 70

671/671 tests pass. Build clean.

Closes backlog #39.