### PR TITLE
feat(oracle): Oil enforcement note when Oil >= 5% and confidence >= 55%

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -284,6 +284,7 @@ ${weekendTemplate}
   parsed.analysis = enforceR031CapNotation(parsed.analysis ?? "", rawConf);
   const executionForceNote = !isWeekend ? buildExecutionForceNote(parsed.analysis ?? "", rawConf) : "";
   const crossAssetNote = !isWeekend ? buildR039R040CrossAssetNote(snapshots, rawConf) : "";
+  const oilEnforcementNote = !isWeekend ? buildOilEnforcementNote(snapshots, rawConf) : "";
   const minSetupNote = buildMinSetupNote(rawConf);
   const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
   const minNonNeutral = rawConf >= 60 ? 4 : 3;
@@ -327,7 +328,7 @@ RULES:
 - Weekend crypto sessions: at least 2 setups from available crypto instruments regardless of confidence
 - Every setup MUST have: entry, stop, target, RR, timeframe
 - ENTRY: nearest support/resistance, session high/low, or key level
-- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}${crossAssetNote}
+- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}${crossAssetNote}${oilEnforcementNote}
 - TARGET: next liquidity level, psychological number, or swing point
 - RR must be > 1.3 \u2014 do not include setups with risk exceeding reward${rrSelfCheckNote}${executionForceNote}
 - Include instrument, type, direction, description, and invalidation
@@ -937,6 +938,39 @@ For EACH instrument in that block you MUST do ONE of:
       - "Conflicting timeframe: [LEVEL] identified but higher timeframe trend conflicts"
 Documenting structural levels then returning zero non-neutral setups without rejection reasons
 is an execution failure (r041). The screening validation block is not a substitute for setup construction.
+`;
+}
+
+// ── Oil enforcement note ───────────────────────────────────
+// When Oil moves ≥5% AND confidence ≥55%, ORACLE must explicitly evaluate Oil —
+// either construct a setup or provide a written rejection reason.
+// Root cause: sessions #201-#203 each had Oil move 5-8% but received no setup
+// because generic screening notes didn't call out Oil specifically.
+export function buildOilEnforcementNote(snapshots: MarketSnapshot[], confidence: number): string {
+  if (confidence < 55) return "";
+
+  const oilSnap = snapshots.find(s => {
+    const n = (s.name ?? "").toLowerCase();
+    const sym = (s.symbol ?? "").toLowerCase();
+    return n.includes("oil") || n.includes("crude") || sym.includes("cl=") || sym.includes("usoil") || sym.includes("wti");
+  });
+
+  if (!oilSnap) return "";
+  if (Math.abs(oilSnap.changePercent ?? 0) < 5) return "";
+
+  const pct = Math.abs(oilSnap.changePercent ?? 0).toFixed(2);
+  const direction = (oilSnap.changePercent ?? 0) > 0 ? "bullish (surge)" : "bearish (crash)";
+
+  return `
+OIL COVERAGE REQUIREMENT (r026 exceptional coordination — MANDATORY):
+Crude Oil has moved ${pct}% this session (${direction}) — an exceptional commodity move.
+At confidence ${confidence}%, you MUST include one of the following for Crude Oil:
+  (a) A COMPLETE setup: entry, stop, target, RR ≥ 1.3, timeframe, direction "bullish" or "bearish", OR
+  (b) An EXPLICIT written rejection in the Oil slot description stating the exact reason:
+      - "Stop distance: structural stop requires X.X% which exceeds 2% maximum"
+      - "Poor RR: entry [PRICE], target [LEVEL] yields only X.X RR — below 1.3 minimum"
+      - "Conflicting structure: [LEVEL] identified but higher timeframe trend invalidates setup"
+Omitting Crude Oil without a written rejection is an execution gap — exceptional moves require explicit evaluation.
 `;
 }
 

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1712,3 +1712,55 @@ describe("enforceR031CapNotation", () => {
     expect(result.toLowerCase()).toContain("capped from 66%");
   });
 });
+
+// ── buildOilEnforcementNote ───────────────────────────────────
+import { buildOilEnforcementNote } from "../src/oracle";
+
+const makeOilSnap = (changePercent: number) => ({
+  symbol: "CL=F", name: "Crude Oil", category: "commodities" as const,
+  price: 90, previousClose: 90 / (1 + changePercent / 100),
+  change: 90 * changePercent / 100, changePercent,
+  high: 92, low: 88, timestamp: new Date(),
+});
+
+describe("buildOilEnforcementNote", () => {
+  it("returns empty string when confidence < 55", () => {
+    expect(buildOilEnforcementNote([makeOilSnap(7)], 54)).toBe("");
+  });
+
+  it("returns empty string when oil move < 5%", () => {
+    expect(buildOilEnforcementNote([makeOilSnap(4.9)], 60)).toBe("");
+  });
+
+  it("returns empty string when no oil snapshot present", () => {
+    const nonOil = [{ symbol: "EURUSD", name: "EUR/USD", category: "forex" as const,
+      price: 1.18, previousClose: 1.17, change: 0.01, changePercent: 0.85,
+      high: 1.185, low: 1.175, timestamp: new Date() }];
+    expect(buildOilEnforcementNote(nonOil, 60)).toBe("");
+  });
+
+  it("returns enforcement note when oil moves >= 5% and confidence >= 55 (sessions #201-#203 regression)", () => {
+    // Sessions #201 (-5.44%), #202 (+7.67%), #203 (+8.50%) all had Oil ≥5% but no setups
+    const note = buildOilEnforcementNote([makeOilSnap(7.67)], 55);
+    expect(note.length).toBeGreaterThan(0);
+    expect(note).toContain("Oil");
+    expect(note).toContain("MANDATORY");
+  });
+
+  it("fires at exactly 5% move and confidence 55 (boundary)", () => {
+    const note = buildOilEnforcementNote([makeOilSnap(5)], 55);
+    expect(note.length).toBeGreaterThan(0);
+  });
+
+  it("fires for negative oil move >= 5% (oil crash like session #201)", () => {
+    const note = buildOilEnforcementNote([makeOilSnap(-5.44)], 58);
+    expect(note.length).toBeGreaterThan(0);
+    expect(note).toContain("Oil");
+  });
+
+  it("detects oil by name 'crude' (symbol variant)", () => {
+    const snap = { ...makeOilSnap(6), symbol: "USOIL", name: "Crude Oil WTI" };
+    const note = buildOilEnforcementNote([snap], 60);
+    expect(note.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem
Sessions #201 (-5.44%), #202 (+7.67%), #203 (+8.50%): Oil moved 5–8% each session but received no setup. `buildExecutionForceNote` and `buildR039R040CrossAssetNote` only enforce broad cross-asset and screening coverage — neither specifically calls out Oil during exceptional commodity moves.

## Fix
New `buildOilEnforcementNote(snapshots, confidence)` in `src/oracle.ts`:
- Fires when confidence ≥ 55% + Oil snapshot present + |changePercent| ≥ 5%
- Injected into ORACLE-SETUPS prompt alongside the existing enforcement notes
- Requires ORACLE to either provide a complete Oil setup OR an explicit written rejection reason (stop distance, poor RR, conflicting structure)

## Tests
6 regression tests covering:
- Confidence < 55 → empty (no false firing)
- Oil move < 5% → empty
- No oil snapshot → empty
- Sessions #201/#202/#203 scenario: 7.67% move, 55% confidence → enforcement note fires
- Exactly 5% boundary fires
- Negative move (oil crash like session #201 -5.44%) fires correctly

679/679 tests pass. Build clean.

Closes backlog #40.