### PR TITLE
fix(oracle/rules): r044 structural depth enforcement, r014/r031 cap reconciliation

### DIFF
--- a/memory/analysis-rules.json
+++ b/memory/analysis-rules.json
@@ -107,7 +107,7 @@
     {
       "id": "r014",
       "category": "confidence_methodology",
-      "description": "Confidence methodology: (1) Technical confluence: 1=20%, 2=35%, 3=45%, 4+=55%. (2) Macro alignment: 40-60% for strong correlation, 20-40% for weak correlation, 0-20% for breakdown. (3) RR clarity: +10% for RR>2.5, +5% for 1.5-2.5, -5% for <1.5. (4) Volatility adjustment: reduce by 10% during VIX>25. (5) Hard cap: maximum confidence 50% regardless of calculation. Analytics show 30-50% range well-calibrated (45% hit rate) while 50-70% range severely overconfident (21% hit rate). NOTE: displayed confidence is system-calibrated — do not modify this rule to compensate for calibration adjustments.",
+      "description": "Confidence methodology: (1) Technical confluence: 1=20%, 2=35%, 3=45%, 4+=55%. (2) Macro alignment: 40-60% for strong correlation, 20-40% for weak correlation, 0-20% for breakdown. (3) RR clarity: +10% for RR>2.5, +5% for 1.5-2.5, -5% for <1.5. (4) Volatility adjustment: reduce by 10% during VIX>25. (5) Calibration cap: superseded by r031 which sets the active hard cap at 65% with mandatory notation — do not add a separate 50% cap. Analytics show 30-50% range well-calibrated (45% hit rate) while 50-70% range severely overconfident (21% hit rate). NOTE: displayed confidence is system-calibrated — do not modify this rule to compensate for calibration adjustments.",
       "weight": 8,
       "addedSession": 2,
       "lastModifiedSession": 108

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -154,6 +154,7 @@ Skipping any instrument on this list is a rule violation (r030).
   const calibrationContext = buildCalibrationContext(allEntries);
 
   const r041Note = !isWeekend ? buildR041ScreeningNote() : "";
+  const r044Note = isWeekend  ? buildR044DepthNote(snapshots, isWeekend) : "";
 
   const analysisUserMessage = `
 ${weekendContext}${marketData}
@@ -185,7 +186,7 @@ FORMAT REQUIREMENTS:
    or correlation breakdown. Otherwise pick a direction (per r015).
 
 4. KEY LEVELS: Identify important support/resistance levels across all instruments.
-${r041Note}
+${r041Note}${r044Note}
 ${buildR011AssumptionNote()}
 
 Respond in JSON:
@@ -866,6 +867,47 @@ export function buildR011AssumptionNote(): string {
    - GOOD: list every attribution in assumptions[], then reference it in the narrative as "(see assumptions)"
    - Use [] ONLY when every move is described purely as price structure with zero interpretive attribution.
      When in doubt, list it.`;
+}
+
+// ── r044 weekend structural depth note ────────────────────
+// Injected into ORACLE-ANALYSIS on weekend sessions when sector divergence >1.0%
+// between infrastructure tokens (BNB, SOL) and utility tokens (XRP, ADA, LINK).
+// Root cause: sessions #212-#214 produced surface-level percentage analysis
+// without order flow, volume clusters, or catalyst context despite >1% divergence.
+export function buildR044DepthNote(snapshots: MarketSnapshot[], isWeekend: boolean): string {
+  if (!isWeekend || !snapshots.length) return "";
+
+  const infraIds  = ["bnb", "binancecoin", "sol", "solana"];
+  const utilityIds = ["xrp", "ripple", "ada", "cardano", "link", "chainlink"];
+
+  function matches(s: MarketSnapshot, ids: string[]): boolean {
+    const n   = s.name.toLowerCase();
+    const sym = s.symbol.toLowerCase().replace(/[^a-z]/g, "");
+    return ids.some(t => n.includes(t) || sym.includes(t));
+  }
+
+  const infraSnaps   = snapshots.filter(s => matches(s, infraIds));
+  const utilitySnaps = snapshots.filter(s => matches(s, utilityIds));
+  if (!infraSnaps.length || !utilitySnaps.length) return "";
+
+  const infraAvg   = infraSnaps.reduce((sum, s) => sum + (s.changePercent ?? 0), 0) / infraSnaps.length;
+  const utilityAvg = utilitySnaps.reduce((sum, s) => sum + (s.changePercent ?? 0), 0) / utilitySnaps.length;
+  const divergence = Math.abs(infraAvg - utilityAvg);
+  if (divergence <= 1.0) return "";
+
+  const sign = (v: number) => v >= 0 ? "+" : "";
+  const infraStr   = infraSnaps.map(s => `${s.name} ${sign(s.changePercent ?? 0)}${(s.changePercent ?? 0).toFixed(1)}%`).join(", ");
+  const utilityStr = utilitySnaps.map(s => `${s.name} ${sign(s.changePercent ?? 0)}${(s.changePercent ?? 0).toFixed(1)}%`).join(", ");
+
+  return `
+SECTOR DIVERGENCE DETECTED (r044 — MANDATORY STRUCTURAL DEPTH):
+Infrastructure tokens (${infraStr}) vs utility tokens (${utilityStr}) diverge by ${divergence.toFixed(1)}% — exceeds 1.0% threshold.
+Your analysis MUST document:
+  1. ORDER FLOW: Identify rejection levels and volume clusters for the diverging groups
+  2. HISTORICAL PRECEDENT: Reference comparable divergence magnitude and what followed
+  3. CATALYST ASSESSMENT: Identify regulatory, institutional, or technical driver
+Superficial percentage comparisons without this structural context constitute an r044 depth violation.
+`;
 }
 
 // ── r041 screening validation note ────────────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote, applyR039R040Penalty, enforceR041ScreeningValidation, reclassifyOtherSetups, buildR011AssumptionNote } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote, applyR039R040Penalty, enforceR041ScreeningValidation, reclassifyOtherSetups, buildR011AssumptionNote, buildR044DepthNote } from "../src/oracle";
 import { resolveConfidence } from "../src/validate";
 import type { MarketSnapshot } from "../src/types";
 
@@ -1804,5 +1804,65 @@ describe("buildR011AssumptionNote", () => {
 
   it("mentions the assumptions array explicitly", () => {
     expect(buildR011AssumptionNote()).toMatch(/assumptions/i);
+  });
+});
+
+// ── buildR044DepthNote ────────────────────────────────────
+
+function makeCryptoSnap(name: string, symbol: string, changePercent: number): MarketSnapshot {
+  return { symbol, name, category: "crypto", price: 100, previousClose: 95, change: 5, changePercent, high: 105, low: 90, timestamp: new Date() };
+}
+
+describe("buildR044DepthNote", () => {
+  const infraSnaps = [
+    makeCryptoSnap("BNB", "BNB-USD", 3.0),  // infra avg = 2.5%
+    makeCryptoSnap("Solana", "SOL-USD", 2.0),
+  ];
+  const utilitySnaps = [
+    makeCryptoSnap("XRP", "XRP-USD", 1.0),   // utility avg = 1.0%
+    makeCryptoSnap("Cardano", "ADA-USD", 1.1),
+    makeCryptoSnap("Chainlink", "LINK-USD", 0.9),
+  ];
+  const allSnaps = [...infraSnaps, ...utilitySnaps];
+
+  it("returns empty string when not a weekend session", () => {
+    expect(buildR044DepthNote(allSnaps, false)).toBe("");
+  });
+
+  it("returns empty string when snapshots array is empty", () => {
+    expect(buildR044DepthNote([], true)).toBe("");
+  });
+
+  it("returns empty string when divergence is exactly 1.0%", () => {
+    // infra avg 2.0%, utility avg 1.0% → divergence = 1.0% (not > 1.0%)
+    const infra = [makeCryptoSnap("BNB", "BNB-USD", 2.0), makeCryptoSnap("Solana", "SOL-USD", 2.0)];
+    const util  = [makeCryptoSnap("XRP", "XRP-USD", 1.0), makeCryptoSnap("Cardano", "ADA-USD", 1.0), makeCryptoSnap("Chainlink", "LINK-USD", 1.0)];
+    expect(buildR044DepthNote([...infra, ...util], true)).toBe("");
+  });
+
+  it("returns empty string when divergence is below 1.0%", () => {
+    const infra = [makeCryptoSnap("BNB", "BNB-USD", 1.5), makeCryptoSnap("Solana", "SOL-USD", 1.5)];
+    const util  = [makeCryptoSnap("XRP", "XRP-USD", 1.0), makeCryptoSnap("Cardano", "ADA-USD", 1.0), makeCryptoSnap("Chainlink", "LINK-USD", 1.0)];
+    expect(buildR044DepthNote([...infra, ...util], true)).toBe("");
+  });
+
+  it("returns non-empty note when divergence exceeds 1.0% on a weekend session (1.5% case)", () => {
+    // infra avg 2.5%, utility avg 1.0% → divergence = 1.5%
+    const note = buildR044DepthNote(allSnaps, true);
+    expect(note.length).toBeGreaterThan(0);
+  });
+
+  it("note references r044", () => {
+    expect(buildR044DepthNote(allSnaps, true)).toMatch(/r044/i);
+  });
+
+  it("note requires order flow and structural context", () => {
+    const note = buildR044DepthNote(allSnaps, true).toLowerCase();
+    expect(note).toMatch(/order flow|volume cluster|rejection level/);
+  });
+
+  it("note requires catalyst assessment", () => {
+    const note = buildR044DepthNote(allSnaps, true).toLowerCase();
+    expect(note).toMatch(/catalyst/);
   });
 });

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -2322,3 +2322,25 @@ describe("validateOracleOutput R:R implausibility cap at 5.0", () => {
     expect(result.warnings.some((w) => w.includes("implausible") && w.includes("RR"))).toBe(true);
   });
 });
+
+// ── r014 vs r031 rule conflict resolution ────────────────
+
+import * as fs from "fs";
+import { ANALYSIS_RULES_PATH } from "../src/utils";
+
+describe("r014 vs r031 rule conflict resolved", () => {
+  it("r014 does not contain an active hard cap at 50% that contradicts r031", () => {
+    const rules = JSON.parse(fs.readFileSync(ANALYSIS_RULES_PATH, "utf-8"));
+    const r014 = rules.rules.find((r: any) => r.id === "r014");
+    expect(r014).toBeDefined();
+    expect(r014.description).not.toMatch(/Hard cap: maximum confidence 50%/);
+  });
+
+  it("r031 remains active with its 65% calibration cap", () => {
+    const rules = JSON.parse(fs.readFileSync(ANALYSIS_RULES_PATH, "utf-8"));
+    const r031 = rules.rules.find((r: any) => r.id === "r031");
+    expect(r031).toBeDefined();
+    expect(r031.disabled).not.toBe(true);
+    expect(r031.description).toMatch(/65%/);
+  });
+});


### PR DESCRIPTION
## Summary

- **Backlog #45 — r044 structural depth enforcement**: Added `buildR044DepthNote()` to `src/oracle.ts`, injected into ORACLE-ANALYSIS on weekend sessions when infra token (BNB, SOL) vs utility token (XRP, ADA, LINK) divergence exceeds 1.0%. Requires order flow (rejection levels, volume clusters), historical precedent, and catalyst assessment. Root cause: sessions #212-#214 produced surface-level percentage analysis despite >1% divergence.
- **Backlog #46 — r014/r031 cap reconciliation**: Removed conflicting "Hard cap: maximum confidence 50%" clause from r014 in `memory/analysis-rules.json`. Replaced with explicit note that r031 supersedes it at 65%. Sessions were silently following only r031; r014's clause was causing confusion without being enforced.

## Test plan

- [ ] 10 new regression tests (8 oracle for `buildR044DepthNote`, 2 validate for rule integrity)
- [ ] 703/703 tests passing (`npx vitest run`)
- [ ] `tsc --noEmit` clean