### PR TITLE
fix(axiom/agent): r011 compliance verdict injection, stagnation streak fix

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -31,7 +31,7 @@ import { buildAnalyticsSummary }                                    from "./anal
 import { fetchRSSNews, formatRSSForPrompt }                          from "./rss";
 import { notifySessionComplete }                                     from "./notifications";
 import { MEMORY_DIR, ANALYSIS_RULES_PATH } from "./utils";
-import type { AnalysisRules, MarketSnapshot, OracleAnalysis, AxiomReflection, ForgeRequest, ForgeResult } from "./types";
+import type { AnalysisRules, MarketSnapshot, OracleAnalysis, AxiomReflection, ForgeRequest, ForgeResult, JournalEntry } from "./types";
 
 // ── Session ID generator ───────────────────────────────────
 
@@ -70,18 +70,29 @@ function buildPreviousSessionsContext(): string {
   return sessionLines + streakLine;
 }
 
-function getNoChangeStreak(): number {
-  const allEntries = loadAllJournalEntries();
+// Pure helper — exported for testing. Counts consecutive sessions from
+// most-recent where AXIOM took no concrete action (no rule updates,
+// no resolved self-tasks, no code changes). resolvedSelfTaskCount and
+// codeChangeCount were added to AxiomReflection so closing developer-fixed
+// tasks also breaks the stagnation streak.
+export function computeNoChangeStreak(entries: JournalEntry[]): number {
   let streak = 0;
-  for (let i = allEntries.length - 1; i >= 0; i--) {
-    const ruleUpdates = allEntries[i].reflection?.ruleUpdates ?? [];
-    if (ruleUpdates.length === 0) {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const r = entries[i].reflection;
+    const ruleUpdates       = r?.ruleUpdates            ?? [];
+    const resolvedTasks     = (r as any)?.resolvedSelfTaskCount ?? 0;
+    const codeChanges       = (r as any)?.codeChangeCount       ?? 0;
+    if (ruleUpdates.length === 0 && resolvedTasks === 0 && codeChanges === 0) {
       streak++;
     } else {
       break;
     }
   }
   return streak;
+}
+
+function getNoChangeStreak(): number {
+  return computeNoChangeStreak(loadAllJournalEntries());
 }
 
 function getConsecutiveZeroSetupCount(): number {

--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -106,6 +106,29 @@ function buildCodebaseContext(openSelfTasksText: string): string {
   return lines.join("\n");
 }
 
+// ── r011 compliance verdict for AXIOM ────────────────────
+// Computes an authoritative r011 verdict from the oracle output so AXIOM
+// doesn't have to guess by scanning narrative text. Prevents false-positive
+// violations when causal language is present but assumptions[] is populated.
+// Root cause of session #216: AXIOM flagged r011 violation despite 3 entries
+// in assumptions[].
+export function buildR011ComplianceNote(oracle: OracleAnalysis | undefined): string {
+  if (!oracle) return "";
+
+  const analysis = oracle.analysis ?? "";
+  const assumptions = oracle.assumptions ?? [];
+  const causalPattern = /\b(suggests?|indicates?|reflects?|driven by|due to)\b/i;
+  const hasCausal = causalPattern.test(analysis);
+
+  if (!hasCausal) {
+    return "\nr011 compliance: No causal attribution language detected — r011 not applicable this session.";
+  }
+  if (assumptions.length > 0) {
+    return `\nr011 compliance: COMPLIANT — causal language present AND assumptions[] populated with ${assumptions.length} entr${assumptions.length === 1 ? "y" : "ies"}. Do NOT flag r011 as a violation this session.`;
+  }
+  return "\nr011 compliance: VIOLATION — causal language detected but assumptions[] is empty. This is a genuine r011 failure.";
+}
+
 // ── Prompt Builder ────────────────────────────────────────
 
 export function buildAxiomPrompt(
@@ -235,6 +258,7 @@ ${(() => {
   }
   return lines.join("\n");
 })()}
+${buildR011ComplianceNote(oracle)}
 
 IMPORTANT ANTI-REPETITION RULES:
 - If a CONFIDENCE ADJUSTMENT NOTICE appeared above, you MUST NOT treat the pipeline enforcement as a rule execution failure or "output mechanism corruption". Do not mention confidence methodology inconsistency in whatFailed. Do not modify r014 or r032.
@@ -263,8 +287,8 @@ ${openSelfTasksText ? openSelfTasksText : "### My open self-tasks: none."}
 ${setupOutcomes ? "### Setup outcome tracking:\n" + setupOutcomes : ""}
 
 ${noChangeStreak >= 3 ? `### STAGNATION ALERT
-You have not modified any rules in ${noChangeStreak} consecutive sessions.
-Your self-critiques are repeating without action.${openSelfTasksText ? ` You have open self-tasks listed above that you have not acted on — generating codeChanges or resolvedSelfTasks for those tasks IS the required concrete action this session. Do not add system prompt text. Do not open new tasks. Act on the existing ones.` : ` This session, you MUST propose at least ONE concrete change — a rule weight adjustment, wording refinement, new rule, or code change.`} Reflection without action is not evolution.
+You have taken no concrete action in ${noChangeStreak} consecutive sessions (no ruleUpdates, resolvedSelfTasks, or codeChanges).
+Your self-critiques are repeating without action.${openSelfTasksText ? ` Required action this session — pick ONE: (a) add or modify a rule (ruleUpdates), (b) generate a code change (codeChanges), or (c) close stale self-tasks via resolvedSelfTasks. If a self-task targets a problem already fixed by a developer PR, resolve it with the PR number — that IS concrete action. Do not open new tasks. Do not add system prompt text.` : ` This session, you MUST propose at least ONE concrete change — a rule weight adjustment, wording refinement, new rule, or code change.`} Any of ruleUpdates, resolvedSelfTasks, or codeChanges will suppress this alert next session. Reflection without action is not evolution.
 ` : ""}${consecutiveZeroSetupCount >= 3 ? `### FORGE ESCALATION — CRITICAL (${consecutiveZeroSetupCount} consecutive sessions with zero setups)
 NEXUS has produced ZERO trading setups for ${consecutiveZeroSetupCount} consecutive sessions despite confidence > 50%.
 Rule modifications have NOT resolved this execution gap.
@@ -641,6 +665,8 @@ export async function runAxiomReflection(
     ruleUpdates:             [...(parsed.ruleUpdates ?? []), ...newRuleEntries],
     newSystemPromptSections: parsed.systemPromptAdditions ?? "",
     evolutionSummary:        parsed.evolutionSummary ?? "",
+    resolvedSelfTaskCount:   (parsed.resolvedSelfTasks ?? []).length,
+    codeChangeCount:         (parsed.codeChanges ?? []).length,
   };
 
   await evolveMemory(currentRules, currentSystemPrompt, parsed, sessionNumber);

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,8 @@ export interface AxiomReflection {
   ruleUpdates: RuleUpdate[];
   newSystemPromptSections: string;
   evolutionSummary: string;
+  resolvedSelfTaskCount: number;
+  codeChangeCount: number;
 }
 
 export interface RuleUpdate {

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -235,3 +235,105 @@ describe("formatComplianceReport", () => {
     expect(result).toContain("3+ sessions in a row");
   });
 });
+
+// ── computeNoChangeStreak ─────────────────────────────────
+
+function makeStreakEntry(opts: {
+  ruleUpdates?: number;
+  resolvedSelfTaskCount?: number;
+  codeChangeCount?: number;
+  sessionNumber?: number;
+} = {}): JournalEntry {
+  return {
+    sessionNumber: opts.sessionNumber ?? 1,
+    date: "2026-04-26",
+    title: "Test session",
+    oracleSummary: "Test summary",
+    axiomSummary: "Test axiom",
+    ruleCount: 44,
+    systemPromptVersion: 110,
+    fullAnalysis: {
+      timestamp: new Date(),
+      sessionId: "test-1",
+      analysis: "Test analysis",
+      bias: { overall: "neutral", notes: "" },
+      confidence: 50,
+      setups: [],
+      keyLevels: [],
+    },
+    reflection: {
+      timestamp: new Date(),
+      sessionId: "test-1",
+      whatWorked: "Test",
+      whatFailed: "Test",
+      cognitiveBiases: [],
+      ruleUpdates: Array(opts.ruleUpdates ?? 0).fill({ ruleId: "r001", type: "modify", reason: "test" }),
+      newSystemPromptSections: "",
+      evolutionSummary: "Test",
+      resolvedSelfTaskCount: opts.resolvedSelfTaskCount ?? 0,
+      codeChangeCount: opts.codeChangeCount ?? 0,
+    },
+  } as any;
+}
+
+describe("computeNoChangeStreak", () => {
+  it("returns 0 for empty entries", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    expect(computeNoChangeStreak([])).toBe(0);
+  });
+
+  it("returns 0 when latest entry has rule updates", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    const entries = [makeStreakEntry({ ruleUpdates: 0 }), makeStreakEntry({ ruleUpdates: 2 })];
+    expect(computeNoChangeStreak(entries)).toBe(0);
+  });
+
+  it("counts consecutive zero-action sessions from most recent", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    const entries = [
+      makeStreakEntry({ ruleUpdates: 1 }),
+      makeStreakEntry({ ruleUpdates: 0 }),
+      makeStreakEntry({ ruleUpdates: 0 }),
+      makeStreakEntry({ ruleUpdates: 0 }),
+    ];
+    expect(computeNoChangeStreak(entries)).toBe(3);
+  });
+
+  it("resets streak when latest entry has resolvedSelfTaskCount > 0", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    const entries = [
+      makeStreakEntry({ ruleUpdates: 0 }),
+      makeStreakEntry({ ruleUpdates: 0 }),
+      makeStreakEntry({ ruleUpdates: 0, resolvedSelfTaskCount: 1 }),
+    ];
+    expect(computeNoChangeStreak(entries)).toBe(0);
+  });
+
+  it("resets streak when latest entry has codeChangeCount > 0", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    const entries = [
+      makeStreakEntry({ ruleUpdates: 0 }),
+      makeStreakEntry({ ruleUpdates: 0 }),
+      makeStreakEntry({ ruleUpdates: 0, codeChangeCount: 1 }),
+    ];
+    expect(computeNoChangeStreak(entries)).toBe(0);
+  });
+
+  it("AXIOM parse failure (empty ruleUpdates, no tasks/code) counts toward streak", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    const failEntry = makeStreakEntry({ ruleUpdates: 0, resolvedSelfTaskCount: 0, codeChangeCount: 0 });
+    (failEntry.reflection as any).whatWorked = "Unable to parse reflection";
+    const entries = [
+      makeStreakEntry({ ruleUpdates: 1 }),
+      failEntry,
+      makeStreakEntry({ ruleUpdates: 0 }),
+    ];
+    expect(computeNoChangeStreak(entries)).toBe(2);
+  });
+
+  it("returns 1 when only last entry has no action", async () => {
+    const { computeNoChangeStreak } = await import("../src/agent");
+    const entries = [makeStreakEntry({ ruleUpdates: 2 }), makeStreakEntry({ ruleUpdates: 0 })];
+    expect(computeNoChangeStreak(entries)).toBe(1);
+  });
+});

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { buildAxiomPrompt, parseAxiomResponse, handleSelfTasks, isThemeDuplicate, sanitizeRulesText } from "../src/axiom";
+import { buildAxiomPrompt, parseAxiomResponse, handleSelfTasks, isThemeDuplicate, sanitizeRulesText, buildR011ComplianceNote } from "../src/axiom";
 import type { OracleAnalysis, AnalysisRules } from "../src/types";
 
 function makeOracle(overrides: Partial<OracleAnalysis> = {}): OracleAnalysis {
@@ -726,5 +726,67 @@ describe("parseAxiomResponse field-boundary salvage", () => {
     // Should get one of the two sentinel values (parse failure or validation failure)
     const sentinels = ["Unable to parse reflection", "Validation failed"];
     expect(sentinels).toContain(result.whatWorked);
+  });
+});
+
+// ── buildR011ComplianceNote ───────────────────────────────
+
+describe("buildR011ComplianceNote", () => {
+  it("returns empty string when oracle is undefined", () => {
+    expect(buildR011ComplianceNote(undefined)).toBe("");
+  });
+
+  it("returns not-applicable note when no causal language present", () => {
+    const oracle = makeOracle({ analysis: "BTC held 77k. ETH tested 2300. Tight ranges across crypto.", assumptions: [] });
+    const note = buildR011ComplianceNote(oracle);
+    expect(note).toMatch(/not applicable|no causal/i);
+  });
+
+  it("returns COMPLIANT when causal language present AND assumptions populated", () => {
+    const oracle = makeOracle({
+      analysis: "BTC suggests underlying strength with infrastructure tokens leading.",
+      assumptions: ["Infrastructure token outperformance suggests risk-on — unconfirmed from price data alone"],
+    });
+    const note = buildR011ComplianceNote(oracle);
+    expect(note).toMatch(/COMPLIANT/);
+    expect(note).toMatch(/Do NOT flag/i);
+  });
+
+  it("COMPLIANT note includes assumptions count", () => {
+    const oracle = makeOracle({
+      analysis: "NASDAQ indicates defensive rotation driven by DXY strength.",
+      assumptions: ["DXY strength driving NASDAQ weakness — unconfirmed", "Defensive rotation inferred from cross-asset correlation"],
+    });
+    const note = buildR011ComplianceNote(oracle);
+    expect(note).toMatch(/2 entr/);
+  });
+
+  it("returns VIOLATION when causal language present AND assumptions empty", () => {
+    const oracle = makeOracle({
+      analysis: "EUR/USD suggests bearish continuation driven by ECB policy.",
+      assumptions: [],
+    });
+    const note = buildR011ComplianceNote(oracle);
+    expect(note).toMatch(/VIOLATION/);
+  });
+
+  it("detects 'indicates' as causal language", () => {
+    const oracle = makeOracle({ analysis: "This indicates a trend reversal.", assumptions: [] });
+    expect(buildR011ComplianceNote(oracle)).toMatch(/VIOLATION/);
+  });
+
+  it("detects 'reflects' as causal language", () => {
+    const oracle = makeOracle({ analysis: "The move reflects macro uncertainty.", assumptions: [] });
+    expect(buildR011ComplianceNote(oracle)).toMatch(/VIOLATION/);
+  });
+
+  it("detects 'driven by' as causal language", () => {
+    const oracle = makeOracle({ analysis: "Rally driven by risk-on sentiment.", assumptions: [] });
+    expect(buildR011ComplianceNote(oracle)).toMatch(/VIOLATION/);
+  });
+
+  it("detects 'due to' as causal language", () => {
+    const oracle = makeOracle({ analysis: "Weakness due to USD strength.", assumptions: [] });
+    expect(buildR011ComplianceNote(oracle)).toMatch(/VIOLATION/);
   });
 });


### PR DESCRIPTION
## Summary

- **Backlog #47 — AXIOM false r011 flag**: Added `buildR011ComplianceNote()` to `src/axiom.ts`. Computes an authoritative r011 verdict from the oracle output (causal language scan + assumptions[] length) and injects it into the AXIOM prompt — same pattern as the r029 per-setup verdicts. AXIOM now reads the pre-computed verdict instead of guessing from narrative text. Root cause of session #216: AXIOM said "without populating assumptions array" despite 3 entries being present.
- **Backlog #48 — Stagnation streak mismatch**: Added `resolvedSelfTaskCount` and `codeChangeCount` to `AxiomReflection` (populated from raw AXIOM JSON). Extracted `computeNoChangeStreak()` as an exported pure function — streak now resets on ruleUpdates OR resolvedSelfTaskCount > 0 OR codeChangeCount > 0. Previously only ruleUpdates reset the streak, but the alert text told AXIOM resolvedSelfTasks and codeChanges also counted. Updated stagnation alert to explicitly tell AXIOM to resolve stale self-tasks for developer-fixed issues.

## Test plan

- [ ] 16 new regression tests (9 axiom for `buildR011ComplianceNote`, 7 agent for `computeNoChangeStreak`)
- [ ] 719/719 tests passing (`npx vitest run`)
- [ ] `tsc --noEmit` clean