### PR TITLE
fix(oracle): large mover coverage — require setup or written rejection for instruments >=3%

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -279,6 +279,7 @@ ${weekendTemplate}
   const executionForceNote = !isWeekend ? buildExecutionForceNote(parsed.analysis ?? "", rawConf) : "";
   const crossAssetNote = !isWeekend ? buildR039R040CrossAssetNote(snapshots, rawConf) : "";
   const oilEnforcementNote = !isWeekend ? buildOilEnforcementNote(snapshots, rawConf) : "";
+  const largeMoverNote = buildLargeMoverCoverageNote(snapshots, rawConf);
   const minSetupNote = buildMinSetupNote(rawConf);
   const weekdayTemplate = !isWeekend ? buildWeekdayScreeningTemplate(snapshots, rawConf) : "";
   const minNonNeutral = rawConf >= 60 ? 4 : 3;
@@ -322,7 +323,7 @@ RULES:
 - Weekend crypto sessions: at least 2 setups from available crypto instruments regardless of confidence
 - Every setup MUST have: entry, stop, target, RR, timeframe
 - ENTRY: nearest support/resistance, session high/low, or key level
-- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}${crossAssetNote}${oilEnforcementNote}
+- STOP: beyond the next structural level, or 1x ATR from entry${r029Note}${crossAssetNote}${oilEnforcementNote}${largeMoverNote}
 - TARGET: next liquidity level, psychological number, or swing point
 - RR must be > 1.3 \u2014 do not include setups with risk exceeding reward${rrSelfCheckNote}${executionForceNote}
 - Include instrument, type, direction, description, and invalidation
@@ -1031,6 +1032,32 @@ At confidence ${confidence}%, you MUST include one of the following for Crude Oi
       - "Conflicting structure: [LEVEL] identified but higher timeframe trend invalidates setup"
 Omitting Crude Oil without a written rejection is an execution gap — exceptional moves require explicit evaluation.
 `;
+}
+
+// ── Large mover coverage enforcement ──────────────────────
+// When any instrument moves ≥3% AND confidence ≥55%, ORACLE must explicitly
+// evaluate that instrument — either construct a complete setup (R:R ≥1.3) or
+// provide a written rejection with exact price math.
+// Root cause: sessions #217-#220 had oil +3.44%, silver -3.84%, platinum -3.83%,
+// XRP -3.37% all left as null/neutral without written rejections, producing only
+// 1 valid setup at 58% confidence and triggering r026/r039/r041 violations.
+export function buildLargeMoverCoverageNote(snapshots: MarketSnapshot[], confidence: number): string {
+  if (confidence < 55) return "";
+  const largeMovers = snapshots.filter(s => Math.abs(s.changePercent ?? 0) >= 3);
+  if (largeMovers.length === 0) return "";
+
+  const lines: string[] = [
+    "",
+    `LARGE MOVER COVERAGE REQUIREMENT (confidence ${confidence}% — MANDATORY):`,
+    `The following instruments moved ≥3% this session. Each MUST have either a complete setup OR a written rejection:`,
+  ];
+  for (const s of largeMovers) {
+    const pct = (s.changePercent ?? 0);
+    const sign = pct > 0 ? "+" : "";
+    lines.push(`  • ${s.name}: ${sign}${pct.toFixed(2)}% — provide (a) entry/stop/target/RR ≥1.3 setup, OR (b) written rejection: "Rejected: entry [X], stop [Y], nearest target [Z] gives R:R [W] — below 1.3 minimum"`);
+  }
+  lines.push(`Returning null/neutral for large movers without a written rejection is an execution failure.`);
+  return lines.join("\n");
 }
 
 // ── RR self-check enforcement ──────────────────────────────

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote, applyR039R040Penalty, enforceR041ScreeningValidation, reclassifyOtherSetups, buildR011AssumptionNote, buildR044DepthNote } from "../src/oracle";
+import { buildR029StopNote, buildWeekdayScreeningTemplate, buildR041ScreeningNote, computeOracleConfidence, buildR039R040CrossAssetNote, applyR039R040Penalty, enforceR041ScreeningValidation, reclassifyOtherSetups, buildR011AssumptionNote, buildR044DepthNote, buildLargeMoverCoverageNote } from "../src/oracle";
 import { resolveConfidence } from "../src/validate";
 import type { MarketSnapshot } from "../src/types";
 
@@ -1864,5 +1864,75 @@ describe("buildR044DepthNote", () => {
   it("note requires catalyst assessment", () => {
     const note = buildR044DepthNote(allSnaps, true).toLowerCase();
     expect(note).toMatch(/catalyst/);
+  });
+});
+
+describe("buildLargeMoverCoverageNote", () => {
+  function makeNamedSnap(name: string, changePercent: number, category = "forex"): MarketSnapshot {
+    return { symbol: "X", name, category, price: 100, previousClose: 100, change: 0, changePercent, high: 101, low: 99, timestamp: new Date() };
+  }
+
+  it("returns empty string when confidence < 55", () => {
+    const snaps = [makeNamedSnap("Crude Oil", 4.0)];
+    expect(buildLargeMoverCoverageNote(snaps, 54)).toBe("");
+  });
+
+  it("returns empty string when no instrument moved >= 3%", () => {
+    const snaps = [makeNamedSnap("EUR/USD", 2.99), makeNamedSnap("Gold", -2.5)];
+    expect(buildLargeMoverCoverageNote(snaps, 60)).toBe("");
+  });
+
+  it("returns note when one instrument moved exactly 3% (boundary)", () => {
+    const note = buildLargeMoverCoverageNote([makeNamedSnap("Silver", 3.0)], 55);
+    expect(note.length).toBeGreaterThan(0);
+  });
+
+  it("includes the instrument name in the note", () => {
+    const note = buildLargeMoverCoverageNote([makeNamedSnap("Crude Oil", 3.44)], 58);
+    expect(note).toMatch(/Crude Oil/);
+  });
+
+  it("includes the move percentage in the note", () => {
+    const note = buildLargeMoverCoverageNote([makeNamedSnap("Silver", -3.84)], 58);
+    expect(note).toMatch(/3\.8/);
+  });
+
+  it("lists multiple large movers when several qualify", () => {
+    const snaps = [
+      makeNamedSnap("Silver", -3.84),
+      makeNamedSnap("Platinum", -3.83),
+      makeNamedSnap("Ripple", -3.37),
+    ];
+    const note = buildLargeMoverCoverageNote(snaps, 58);
+    expect(note).toMatch(/Silver/);
+    expect(note).toMatch(/Platinum/);
+    expect(note).toMatch(/Ripple/);
+  });
+
+  it("does NOT include instruments that moved less than 3%", () => {
+    const snaps = [makeNamedSnap("EUR/USD", 2.99), makeNamedSnap("Gold", 3.5)];
+    const note = buildLargeMoverCoverageNote(snaps, 58);
+    expect(note).not.toMatch(/EUR\/USD/);
+    expect(note).toMatch(/Gold/);
+  });
+
+  it("requires explicit written rejection when setup not viable", () => {
+    const note = buildLargeMoverCoverageNote([makeNamedSnap("Crude Oil", 3.5)], 60).toLowerCase();
+    expect(note).toMatch(/rejection|rejected|reject|written/);
+  });
+
+  it("requires R:R >= 1.3 in setup or rejection reason", () => {
+    const note = buildLargeMoverCoverageNote([makeNamedSnap("Gold", -4.0)], 60);
+    expect(note).toMatch(/1\.3/);
+  });
+
+  it("handles negative (bearish) large moves correctly", () => {
+    const note = buildLargeMoverCoverageNote([makeNamedSnap("Bitcoin", -5.0)], 60);
+    expect(note).toMatch(/Bitcoin/);
+    expect(note.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty when snapshots array is empty", () => {
+    expect(buildLargeMoverCoverageNote([], 60)).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `buildLargeMoverCoverageNote()` to `src/oracle.ts` — injected into ORACLE-SETUPS prompt alongside existing oil and execution-force notes
- When any instrument moves ≥3% AND confidence ≥55%, ORACLE must either construct a complete setup (R:R ≥1.3) or write an explicit rejection with exact price math
- 11 regression tests covering boundary cases, multi-instrument, bearish moves, and rejection language

## Root Cause
Sessions #217–#220 had silver -3.84%, platinum -3.83%, XRP -3.37%, oil +3.44% all returned as null/neutral without written rejections. Only 1 valid setup survived at 58% confidence, triggering r026/r039/r041 violations and dropping confidence to 38%.

The existing `buildExecutionForceNote` requires rejection reasons for instruments in the screening block, but ORACLE was bypassing it by returning null+neutral. The new note explicitly names each ≥3% mover and repeats the requirement inline.

## Test plan
- [ ] `npx vitest run` — 730 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] Next session with ≥3% movers should produce either valid setups or explicit written rejections for those instruments