### PR TITLE
fix(axiom): suppress r011 false-positive from whatFailed when assumptions[] populated

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -559,6 +559,28 @@ export function parseAxiomResponse(
     }
   }
 
+  // r011 false-positive suppression: if AXIOM complained about r011/causal attribution
+  // but oracle.assumptions[] is populated, strip the false-flag from whatFailed and
+  // suppress r011 self-tasks. AXIOM pattern-matches to session history and ignores the
+  // compliance verdict injected into its prompt.
+  // Root cause: sessions #217-#221 had assumptions[] populated but AXIOM still flagged
+  // r011 because prior session journals all said "r011 violation".
+  if (oracle) {
+    const assumptions = (oracle as any).assumptions ?? [];
+    const whatFailed = parsed.whatFailed ?? "";
+    if (assumptions.length > 0 && /r011|causal attribution|assumptions array/i.test(whatFailed)) {
+      // Strip sentences containing r011 / causal attribution from whatFailed
+      const sentences = whatFailed.split(/(?<=[.!?])\s+/);
+      const filtered = sentences.filter((s: string) => !/r011|causal attribution|assumptions array/i.test(s));
+      parsed.whatFailed = filtered.join(" ").trim() || "No significant failures this session.";
+      // Suppress any r011 self-tasks
+      parsed.newSelfTasks = (parsed.newSelfTasks ?? []).filter(
+        (t: any) => !/r011|causal attribution|assumptions/i.test(t.title ?? "")
+      );
+      console.warn(`  ⚠ Axiom: r011 false positive suppressed — AXIOM cited causal attribution failure but assumptions[] is populated with ${assumptions.length} entries`);
+    }
+  }
+
   return parsed;
 }
 

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -790,3 +790,73 @@ describe("buildR011ComplianceNote", () => {
     expect(buildR011ComplianceNote(oracle)).toMatch(/VIOLATION/);
   });
 });
+
+describe("parseAxiomResponse — r011 false-positive suppression", () => {
+  const rules = makeRules();
+
+  function makeAxiomJson(whatFailed: string, selfTasks: any[] = []): string {
+    return JSON.stringify({
+      whatWorked: "Good screening",
+      whatFailed,
+      cognitiveBiases: [],
+      evolutionSummary: "Learned something",
+      ruleUpdates: [],
+      newRules: [],
+      systemPromptAdditions: "",
+      newSelfTasks: selfTasks,
+      resolvedSelfTasks: [],
+      codeChanges: [],
+    });
+  }
+
+  it("strips r011 violation sentence from whatFailed when oracle.assumptions is populated", () => {
+    const oracle = makeOracle({ assumptions: ["Iran tensions driving oil", "USD strength from safe haven"], analysis: "Oil suggests geopolitical catalyst." });
+    const result = parseAxiomResponse(makeAxiomJson("Systematic r011 causal attribution violation persists."), 1, rules, oracle);
+    expect(result.whatFailed).not.toMatch(/r011/i);
+  });
+
+  it("preserves non-r011 content in whatFailed after r011 suppression", () => {
+    const oracle = makeOracle({ assumptions: ["Iran geopolitical attribution"], analysis: "This indicates a move." });
+    const result = parseAxiomResponse(makeAxiomJson("r011 causal attribution failure. Also missed 4 setups in forex."), 1, rules, oracle);
+    expect(result.whatFailed).not.toMatch(/r011/i);
+    expect(result.whatFailed).toMatch(/4 setups/i);
+  });
+
+  it("does NOT suppress when oracle.assumptions is empty (genuine violation)", () => {
+    const oracle = makeOracle({ assumptions: [], analysis: "Oil indicates geopolitical risk." });
+    const result = parseAxiomResponse(makeAxiomJson("r011 causal attribution violation — assumptions array empty."), 1, rules, oracle);
+    expect(result.whatFailed).toMatch(/r011/i);
+  });
+
+  it("does NOT suppress when oracle is undefined", () => {
+    const result = parseAxiomResponse(makeAxiomJson("r011 causal attribution violation."), 1, rules, undefined);
+    expect(result.whatFailed).toMatch(/r011/i);
+  });
+
+  it("does NOT modify whatFailed when r011 is not mentioned", () => {
+    const oracle = makeOracle({ assumptions: ["some assumption"], analysis: "This suggests a move." });
+    const result = parseAxiomResponse(makeAxiomJson("Missed EUR/USD setup. Confidence too low."), 1, rules, oracle);
+    expect(result.whatFailed).toMatch(/EUR\/USD/);
+  });
+
+  it("suppresses r011 self-task when assumptions are populated", () => {
+    const oracle = makeOracle({ assumptions: ["some attribution"], analysis: "This reflects risk sentiment." });
+    const selfTask = { title: "Fix r011 causal attribution violations", body: "r011 keeps being violated", category: "rule-gap", priority: "high" };
+    const result = parseAxiomResponse(makeAxiomJson("r011 violation detected.", [selfTask]), 1, rules, oracle);
+    const hasr011Task = (result.newSelfTasks ?? []).some((t: any) => /r011|causal attribution/i.test(t.title ?? ""));
+    expect(hasr011Task).toBe(false);
+  });
+
+  it("keeps non-r011 self-tasks when suppressing r011", () => {
+    const oracle = makeOracle({ assumptions: ["some attribution"], analysis: "This suggests a move." });
+    const tasks = [
+      { title: "Fix r011 causal attribution", body: "r011 issue description", category: "rule-gap", priority: "high" },
+      { title: "Improve setup coverage for forex", body: "forex coverage description", category: "rule-gap", priority: "medium" },
+    ];
+    const result = parseAxiomResponse(makeAxiomJson("r011 violation. Also forex coverage gap.", tasks), 1, rules, oracle);
+    const hasr011Task = (result.newSelfTasks ?? []).some((t: any) => /r011/i.test(t.title ?? ""));
+    const hasForexTask = (result.newSelfTasks ?? []).some((t: any) => /forex/i.test(t.title ?? ""));
+    expect(hasr011Task).toBe(false);
+    expect(hasForexTask).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds r011 false-positive suppression in `parseAxiomResponse` (same pattern as existing r029 suppression from PR #98)
- When `oracle.assumptions[]` is non-empty AND `whatFailed` mentions r011/causal attribution: strips the false-flag sentences from `whatFailed` and removes r011 self-tasks
- 7 regression tests added

## Root Cause
Sessions #217–#221 all had `assumptions[]` populated (4-5 entries). `buildR011ComplianceNote()` correctly injected "COMPLIANT — do not flag r011" into the AXIOM prompt. But AXIOM ignored the instruction because ~8 prior session journals all contain "r011 violation" — pattern-matching overwhelmed the compliance note.

Post-processing the output is more reliable than an LLM instruction that competes with training data.

## What changes
- `src/axiom.ts`: new suppression block after r029 suppression (line ~562)
- `tests/axiom.test.ts`: 7 tests covering suppression, preservation of non-r011 content, self-task filtering, genuine violation pass-through

## Test plan
- [ ] `npx vitest run` — 737 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] Next session: AXIOM `whatFailed` should no longer mention r011 when assumptions are populated; journal should reflect accurate failures only