### PR TITLE
fix(oracle): extend reclassifyOtherSetups with session #221 missed patterns

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -802,8 +802,13 @@ export function reclassifyOtherSetups(setups: any[]): any[] {
     { type: "OB",             patterns: /order\s+block|\bob\b|mitigation\s+block|institutional\s+(level|order)/i },
     { type: "CISD",           patterns: /\bcisd\b|change\s+in\s+state\s+of\s+delivery|displacement\s+candle/i },
     { type: "Liquidity Sweep",patterns: /liquidity\s+sweep|stop\s+hunt|liquidity\s+grab|equal\s+highs|equal\s+lows|sell.?side\s+liquidity|buy.?side\s+liquidity|oversold.{0,100}(bounce|reversal|reversion|recovery)|(extreme|severe).{0,20}(decline|collapse|drop|fall).{0,60}(bounce|reversal)|(supply|demand)\s+shock.{0,20}(exhaustion|bounce|reversal)/i },
-    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low|session\s+(high|low)|psychological\s+(level|support|number)|(approaching|testing|near|rejection\s+from|rejecting)\s+.{0,30}(key\s+|major\s+|critical\s+|psychological\s+)?(resistance|support)|rejection\s+from\s+.{0,20}(high|low)\b|(resistance|support).{0,30}being\s+tested/i },
-    { type: "MSS",            patterns: /market\s+structure\s+shift|structure\s+(break|shift)|structural\s+break|\bmss\b|\bmomentum\b|breakout|breaking\s+(above|below)|break\s+(above|below)/i },
+    // High-priority MSS: continuation/momentum patterns must fire BEFORE PDH/PDL
+    // so "USD strength continuation ... targeting support" goes to MSS, not PDH/PDL.
+    // Also catches "\bmomentum\b" descriptions like "driving momentum above X, targeting Y resistance"
+    // before PDH/PDL's "targeting ... resistance" can steal them.
+    { type: "MSS",            patterns: /\b(momentum|strength|weakness|trend)\s+continuation\b|\bmomentum\b/i },
+    { type: "PDH/PDL",        patterns: /\bpdh\b|\bpdl\b|previous\s+day\s+high|previous\s+day\s+low|prior\s+day\s+high|prior\s+day\s+low|session\s+(high|low)|psychological\s+(level|support|number)|(approaching|testing|near|rejection\s+from|rejecting)\s+.{0,30}(key\s+|major\s+|critical\s+|psychological\s+)?(resistance|support)|rejection\s+from\s+.{0,20}(high|low)\b|(resistance|support).{0,30}being\s+tested|targeting.{0,40}(support|resistance)|support\s+breakdown|resistance\s+breakdown/i },
+    { type: "MSS",            patterns: /market\s+structure\s+shift|structure\s+(break|shift)|structural\s+break|\bmss\b|breakout|breaking\s+(above|below)|break\s+(above|below)/i },
   ];
 
   return setups.map(setup => {

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1936,3 +1936,51 @@ describe("buildLargeMoverCoverageNote", () => {
     expect(buildLargeMoverCoverageNote([], 60)).toBe("");
   });
 });
+
+describe("reclassifyOtherSetups — session #221 regression patterns", () => {
+  function makeOther(instrument: string, description: string): any {
+    return { instrument, type: "Other", direction: "bearish", description, entry: 1.17, stop: 1.18, target: 1.16, RR: 1.5, timeframe: "4H" };
+  }
+
+  it("reclassifies EUR/USD 'strength continuation' to MSS (session #221 pattern)", () => {
+    const setup = makeOther("EUR/USD", "USD strength continuation amid broad DXY surge, targeting 1.1650 support breakdown");
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("MSS");
+  });
+
+  it("reclassifies Ethereum 'targeting support' to PDH/PDL (session #221 pattern)", () => {
+    const setup = makeOther("Ethereum", "Following BTC weakness, targeting 2200 support with crypto sector risk-off");
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("PDH/PDL");
+  });
+
+  it("reclassifies Gold 'targeting support breakdown' to PDH/PDL (session #221 pattern)", () => {
+    const setup = makeOther("Gold", "Risk-on precious metals selloff -2.47% targeting 4550 support breakdown amid USD strength");
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("PDH/PDL");
+  });
+
+  it("reclassifies 'weakness continuation' to MSS", () => {
+    const setup = makeOther("GBP/USD", "GBP weakness continuation below 1.3450 structure break targeting 1.34");
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("MSS");
+  });
+
+  it("reclassifies 'targeting resistance with momentum continuation' to MSS (momentum takes priority)", () => {
+    const setup = makeOther("USD/CHF", "USD strength targeting 0.80 resistance with momentum continuation");
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("MSS");
+  });
+
+  it("reclassifies 'support breakdown' to PDH/PDL", () => {
+    const setup = makeOther("Silver", "Precious metals support breakdown below 30.00, targeting 29.50");
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("PDH/PDL");
+  });
+
+  it("does not reclassify already-classified setups", () => {
+    const setup = { ...makeOther("Gold", "targeting 4550 support"), type: "OB" };
+    const [result] = reclassifyOtherSetups([setup]);
+    expect(result.type).toBe("OB");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `targeting ... support/resistance` and `support/resistance breakdown` patterns to PDH/PDL in `reclassifyOtherSetups()`
- Adds high-priority MSS rule for `momentum|strength|weakness continuation` and `\bmomentum\b` placed **before** PDH/PDL to prevent the new targeting pattern from stealing momentum-driven setups
- 7 regression tests

## Root Cause
Session #221 had 3/4 setups typed as "Other":
- EUR/USD: "USD strength continuation ... targeting 1.1650 support breakdown" → should be MSS
- Ethereum: "Following BTC weakness, targeting 2200 support" → should be PDH/PDL
- Gold: "precious metals selloff targeting 4550 support breakdown" → should be PDH/PDL

None matched existing patterns. AXIOM added r045 to address this but code enforcement was missing.

## Test plan
- [ ] `npx vitest run` — 744 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] Next session with "Other" setups matching these descriptions should be reclassified automatically