### PR TITLE
fix(axiom): prevent r029 hallucination for instruments with no setup

### DIFF
--- a/src/axiom.ts
+++ b/src/axiom.ts
@@ -230,10 +230,14 @@ ${(() => {
   // Per-setup validation results so AXIOM sees explicit COMPLIANT/VIOLATION verdicts
   const setups = oracle.setups ?? [];
   const setupLines: string[] = [];
+  // Track which volatile instruments actually have a setup so we can flag the rest
+  const instrumentsWithSetup = new Set<string>();
   for (const setup of setups) {
     if (typeof (setup as any).entry !== "number" || typeof (setup as any).stop !== "number") continue;
     const instrKey = ((setup as any).instrument ?? "").toLowerCase();
     const instrKeyNorm = instrKey.replace(/[^a-z0-9]/g, "");
+    instrumentsWithSetup.add(instrKey);
+    instrumentsWithSetup.add(instrKeyNorm);
     const instrMove = volatilityMap.get(instrKey) ?? volatilityMap.get(instrKeyNorm) ?? 0;
     const stopPct = (Math.abs((setup as any).entry - (setup as any).stop) / (setup as any).entry) * 100;
     let verdict: string;
@@ -250,11 +254,20 @@ ${(() => {
     }
     setupLines.push(`  - ${(setup as any).instrument}: stop ${stopPct.toFixed(2)}% — ${verdict}`);
   }
+  // Explicitly mark volatile instruments that have NO setup — prevents AXIOM from inventing violations
+  for (const s of [...extreme, ...moderate]) {
+    const key = s.name.toLowerCase();
+    const keyNorm = key.replace(/[^a-z0-9]/g, "");
+    if (!instrumentsWithSetup.has(key) && !instrumentsWithSetup.has(keyNorm)) {
+      setupLines.push(`  - ${s.name}: NO SETUP this session — r029 not applicable (moved ${Math.abs(s.changePercent ?? 0).toFixed(1)}% but no setup was constructed)`);
+    }
+  }
   if (setupLines.length) {
     lines.push("");
     lines.push("r029 validation per setup (authoritative — do not contradict these verdicts):");
     lines.push(...setupLines);
     lines.push("Stops marked COMPLIANT are NOT r029 violations. Do NOT report them as failures.");
+    lines.push("Instruments marked NO SETUP have no stop to validate — do NOT invent r029 violations for them.");
   }
   return lines.join("\n");
 })()}
@@ -546,7 +559,8 @@ export function parseAxiomResponse(
   }
 
   // r029 false-positive suppression: if AXIOM complained about r029/stop violations
-  // but all setups are actually per-instrument compliant, remove the injected self-task.
+  // but all setups are actually per-instrument compliant, remove the injected self-task
+  // AND scrub the hallucinated complaint from whatFailed so it doesn't pollute the journal.
   // This prevents repeated false alerts when AXIOM applies global-max reasoning despite
   // the per-instrument compliance verdicts injected into its prompt.
   if (oracle && /r029|stop distance|stop.*violation|violation.*stop/i.test(rawParsed.whatFailed ?? "")) {
@@ -555,6 +569,15 @@ export function parseAxiomResponse(
       parsed.newSelfTasks = (parsed.newSelfTasks ?? []).filter(
         (t: any) => t.category !== "rule-gap"
       );
+      // Also scrub the r029 hallucination from whatFailed sentence-by-sentence,
+      // preserving any non-r029 content (e.g. "Single asset class coverage only.")
+      if (parsed.whatFailed) {
+        parsed.whatFailed = parsed.whatFailed
+          .split(/(?<=[.!?])\s+/)
+          .filter((sentence: string) => !/r029|stop distance|stop.*violation|violation.*stop/i.test(sentence))
+          .join(" ")
+          .trim();
+      }
       console.warn("  ⚠ Axiom: r029 false positive suppressed — AXIOM cited stop violations but all setups are per-instrument compliant");
     }
   }

--- a/tests/axiom.test.ts
+++ b/tests/axiom.test.ts
@@ -253,6 +253,30 @@ describe("buildAxiomPrompt", () => {
     const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
     expect(userMessage).toMatch(/Crude Oil.*VIOLATION|VIOLATION.*Crude Oil/i);
   });
+
+  // ── regression: #51 — AXIOM hallucinates oil r029 violation when no oil setup exists ──
+
+  it("explicitly marks oil as NO SETUP when oil moved ≥3% but no oil setup was constructed (regression #51)", () => {
+    // Session #222 root cause: oil moved 3.6%, NASDAQ+DAX were the only setups.
+    // The r029 note listed "≥3% (requires ≥1.0% stop): Crude Oil" in the header
+    // but produced no per-setup verdict for oil → AXIOM invented a violation.
+    const snapshots = [
+      { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 99.31, previousClose: 95.85, change: 3.46, changePercent: 3.61, high: 100, low: 95, timestamp: new Date() },
+      { name: "NASDAQ 100", symbol: "NAS100", category: "indices" as const, price: 27029, previousClose: 26480, change: 549, changePercent: 2.08, high: 27100, low: 26700, timestamp: new Date() },
+    ];
+    const setups: any[] = [
+      // NASDAQ setup only — no oil setup
+      { instrument: "NASDAQ 100", type: "MSS", direction: "bullish", description: "breakout", invalidation: "below 26800",
+        entry: 27029, stop: 26750, target: 27450, RR: 1.51, timeframe: "4H" },
+    ];
+    const oracle = makeOracle({ marketSnapshots: snapshots, setups });
+    const rules = makeRules();
+    const { userMessage } = buildAxiomPrompt(oracle, 1, "", "", "", 0, "", rules, "");
+    // Must explicitly say oil has no setup — not just show the header volatility requirement
+    expect(userMessage).toMatch(/Crude Oil.*NO SETUP|NO SETUP.*Crude Oil/i);
+    // Must NOT show a VIOLATION verdict for oil (there is no setup to violate)
+    expect(userMessage).not.toMatch(/Crude Oil.*VIOLATION|VIOLATION.*Crude Oil/i);
+  });
 });
 
 // ── parseAxiomResponse ────────────────────────────────────
@@ -858,5 +882,37 @@ describe("parseAxiomResponse — r011 false-positive suppression", () => {
     const hasForexTask = (result.newSelfTasks ?? []).some((t: any) => /forex/i.test(t.title ?? ""));
     expect(hasr011Task).toBe(false);
     expect(hasForexTask).toBe(true);
+  });
+
+  // ── regression: #51 — r029 hallucination scrubbed from whatFailed ──
+
+  it("scrubs r029 oil violation from whatFailed when no oil setup exists (regression #51)", () => {
+    // Session #222: AXIOM wrote "Critical r029 violation on crude oil setup" in whatFailed
+    // but no oil setup existed. The false-positive suppressor stripped the self-task
+    // but left the hallucinated text in whatFailed, polluting the journal entry.
+    const oracle = makeOracle({
+      marketSnapshots: [
+        { name: "Crude Oil", symbol: "OIL", category: "commodities" as const, price: 99.31, previousClose: 95.85, change: 3.46, changePercent: 3.61, high: 100, low: 95, timestamp: new Date() },
+        { name: "NASDAQ 100", symbol: "NAS100", category: "indices" as const, price: 27029, previousClose: 26480, change: 549, changePercent: 2.08, high: 27100, low: 26700, timestamp: new Date() },
+      ],
+      setups: [
+        { instrument: "NASDAQ 100", type: "MSS", direction: "bullish", description: "breakout", invalidation: "below 26800",
+          entry: 27029, stop: 26750, target: 27450, RR: 1.51, timeframe: "4H" },
+      ],
+    });
+    const whatFailed = "Critical r029 violation on crude oil setup - stop distance only 0.82% despite instrument moving 3.6%. Single asset class coverage only.";
+    const json = JSON.stringify({
+      whatWorked: "Good cross-asset analysis",
+      whatFailed,
+      cognitiveBiases: ["volatility anchoring"],
+      evolutionSummary: "Identified stop distance gap",
+      ruleUpdates: [], newRules: [], systemPromptAdditions: "",
+      newSelfTasks: [], resolvedSelfTasks: [], codeChanges: [],
+    });
+    const result = parseAxiomResponse(json, 222, rules, oracle);
+    // Hallucinated r029 oil complaint must be removed from whatFailed
+    expect(result.whatFailed).not.toMatch(/r029.*crude oil|crude oil.*r029/i);
+    // Non-r029 content must survive
+    expect(result.whatFailed).toMatch(/single asset class/i);
   });
 });


### PR DESCRIPTION
## Summary

- **`buildR029VerdictNote()`**: for every volatile instrument (≥3% or ≥5% session move) that has **no corresponding setup**, now emits an explicit \`NO SETUP this session — r029 not applicable\` line in the per-instrument verdict block. Previously AXIOM saw the volatility requirement in the header but no verdict for that instrument and invented a violation.
- **`parseAxiomResponse()` false-positive suppressor**: when \`actualViolations.length === 0\`, now also scrubs the hallucinated r029 complaint from \`whatFailed\` sentence-by-sentence, preserving any genuine non-r029 failure text. Previously it stripped only the injected self-task, leaving bad text in the journal entry.

## Regression confirmed

Sessions #219 and #222 both triggered this bug. Session #222 (2026-04-29): setups were NASDAQ + DAX only; no crude oil setup. AXIOM whatFailed: "Critical r029 violation on crude oil setup - stop distance only 0.82% despite instrument moving 3.6%."

## Test plan

- [x] `buildAxiomPrompt` — oil moved ≥3%, no oil setup → prompt contains NO SETUP for oil, no VIOLATION for oil
- [x] `parseAxiomResponse` — AXIOM reports r029 oil violation, no oil setup → whatFailed scrubbed of r029 complaint, non-r029 content preserved
- [x] All 746 existing tests pass (no regressions)