### PR TITLE
fix(oracle): explicitly warn that same-class setups don't satisfy r039 cross-asset requirement

### DIFF
--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -978,7 +978,14 @@ You MUST either:
       • Poor RR (<1.3) at the identified structural level
       • Stop distance >2% required
       • Conflicting higher timeframe structure
-Submitting only forex setups when indices, crypto, and commodities are all moving is a RULE VIOLATION.
+
+IMPORTANT — "different asset class" means different CATEGORY, not different instrument:
+  ✗ NASDAQ 100 + DAX = both indices = SAME class = NOT cross-asset coverage
+  ✗ EUR/USD + GBP/USD = both forex = SAME class = NOT cross-asset coverage
+  ✓ NASDAQ 100 (indices) + EUR/USD (forex) = 2 different classes = compliant
+  ✓ Bitcoin (crypto) + Crude Oil (commodities) + EUR/USD (forex) = 3 classes = compliant
+
+Submitting only forex setups, or only indices setups, when multiple asset classes are moving is a RULE VIOLATION.
 `;
 }
 

--- a/tests/oracle.test.ts
+++ b/tests/oracle.test.ts
@@ -1266,6 +1266,23 @@ describe("buildR039R040CrossAssetNote", () => {
     const note = buildR039R040CrossAssetNote(multiClassSnaps, 67);
     expect(note).toContain("67%");
   });
+
+  // ── regression: #53 — note must clarify that two index setups = same class ──
+
+  it("explicitly warns that NASDAQ+DAX = same asset class = not cross-asset (regression #53)", () => {
+    // Session #222 root cause: ORACLE produced NASDAQ 100 + DAX setups — both indices.
+    // The prompt said "AT LEAST 2 DIFFERENT asset classes" but didn't give concrete
+    // examples, so ORACLE counted 2 setups and thought it complied.
+    const snaps = [
+      makeCrossSnap("NASDAQ 100", "NAS100",  2.08), // indices >2%
+      makeCrossSnap("Crude Oil",  "OIL",     3.61), // commodities >2%
+      makeCrossSnap("XRP",        "XRP",    -2.84), // crypto >2%
+      makeCrossSnap("DAX",        "DAX",    -1.04), // indices <2%
+    ];
+    const note = buildR039R040CrossAssetNote(snaps, 57);
+    // Must explicitly clarify what "different" means — same class doesn't count
+    expect(note).toMatch(/nasdaq.*dax.*same|dax.*nasdaq.*same|indices.*same|same.*class|NASDAQ.*DAX.*same/i);
+  });
 });
 
 // ── r031 auto-cap in computeOracleConfidence ──────────────
@@ -1376,6 +1393,21 @@ describe("applyR039R040Penalty", () => {
   it("reason string mentions r039 or r040", () => {
     const result = applyR039R040Penalty(67, multiSnaps, forexOnlySetups, false);
     expect(result.reason).toMatch(/r039|r040/i);
+  });
+
+  // ── regression: #53 — indices-only setups must be penalized like forex-only ──
+
+  it("penalizes indices-only setups (NASDAQ+DAX) as single-class coverage (regression #53)", () => {
+    // Session #222: NASDAQ 100 + DAX both classify as "indices" — setupClasses.size = 1.
+    // Penalty should fire just as it does for forex-only setups.
+    const indicesOnlySetups = [
+      { instrument: "NASDAQ 100", entry: 27029, stop: 26750, target: 27450 },
+      { instrument: "DAX",        entry: 24018, stop: 24280, target: 23650 },
+    ];
+    const result = applyR039R040Penalty(57, multiSnaps, indicesOnlySetups, false);
+    expect(result.penalized).toBeLessThan(57);
+    expect(result.reason).not.toBeNull();
+    expect(result.reason).toMatch(/r039/i);
   });
 });
 


### PR DESCRIPTION
## Summary

- **`buildR039R040CrossAssetNote()`**: adds a concrete examples block to the prompt note making "different asset class" unambiguous. ORACLE can no longer count NASDAQ + DAX as cross-asset coverage.
- **`applyR039R040Penalty()`**: confirmed already correctly classifies indices-only setups as single-class (no code change needed — penalty was firing). New regression test verifies this.

## Root cause (session #222)

ORACLE produced NASDAQ 100 (indices) + DAX (indices) setups at 57% confidence with 3 asset classes moving >2%. The prompt said "AT LEAST 2 DIFFERENT asset classes" without defining "different." ORACLE counted 2 setups = 2 classes.

New explicit block in the prompt:
```
✗ NASDAQ 100 + DAX = both indices = SAME class = NOT cross-asset coverage
✗ EUR/USD + GBP/USD = both forex = SAME class = NOT cross-asset coverage
✓ NASDAQ 100 (indices) + EUR/USD (forex) = 2 different classes = compliant
```

## Test plan

- [x] `buildR039R040CrossAssetNote` — note contains explicit same-class language for NASDAQ+DAX scenario
- [x] `applyR039R040Penalty` — indices-only setups (NASDAQ+DAX) correctly penalized as single-class
- [x] All 748 tests pass (no regressions)