### PR TITLE
fix(agent): re-apply setup count penalty after r029/r036 filtering

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -26,7 +26,7 @@ import {
   loadAllJournalEntries,
   saveJournalEntry,
 } from "./journal";
-import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, logFailure, loadRecentFailures } from "./validate";
+import { validateOracleOutput, validateWeekendCryptoScreening, filterNonCompliantSetups, filterR036Setups, logFailure, loadRecentFailures, applySetupCountPenalty } from "./validate";
 import { buildAnalyticsSummary }                                    from "./analytics";
 import { fetchRSSNews, formatRSSForPrompt }                          from "./rss";
 import { notifySessionComplete }                                     from "./notifications";
@@ -569,6 +569,23 @@ export async function runAndValidateOracle(
       console.warn(`  ⚠ r036: removed setup [${r.instrument}] — ${r.reason}`);
     }
     oracle = r036FilteredOracle;
+  }
+
+  // Re-apply setup count penalty if r029/r036 filtering reduced the setup count after
+  // computeOracleConfidence() already computed confidence using the pre-filter count.
+  // Example (session #222): ORACLE produced 3 setups → no penalty at 57%. filterNonCompliantSetups
+  // removed the Oil setup (0.82% stop, oil moved 3.6%) → 2 setups remain, confidence never recomputed.
+  // We call applySetupCountPenalty on the already-penalised confidence, which is safe because:
+  //   • if count didn't change, same threshold applies → no new penalty
+  //   • if count dropped below threshold, penalty fires on the already-penalised value
+  //   • if already-penalised value is ≤50%, minSetups=0 → no double-penalty (backlog #23 guard)
+  // Do NOT call resolveConfidence() — it would undo prior penalties (backlog #23).
+  const { penalized: postFilterConf, reason: postFilterReason } = applySetupCountPenalty(
+    oracle.confidence, oracle.setups.length, weekendMode
+  );
+  if (postFilterReason) {
+    console.warn(`  ⚠ Post-filter setup count penalty: ${postFilterReason}`);
+    oracle = { ...oracle, confidence: postFilterConf };
   }
 
   // Note: confidence is already resolved and penalized by computeOracleConfidence() inside

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1948,6 +1948,36 @@ describe("applySetupCountPenalty", () => {
     // Actually weekend always requires 2, so this should penalize
     expect(result.penalized).toBe(35);
   });
+
+  // ── regression: #49 — 55-65% confidence with <3 setups after r029 filtering ──
+
+  it("penalizes 2 setups at 57% confidence (session #222 post-r029-filter scenario)", () => {
+    // Session #222: ORACLE produced 3 setups (NASDAQ, DAX, Crude Oil).
+    // computeOracleConfidence saw 3 setups → no penalty at 57%.
+    // filterNonCompliantSetups removed Crude Oil (0.82% stop, oil moved 3.6%).
+    // After filtering: 2 setups remain, confidence should be re-penalised.
+    // This test verifies the penalty function returns the right value for the
+    // post-filter inputs (agent.ts re-application is the integration fix).
+    const result = applySetupCountPenalty(57, 2, false);
+    expect(result.penalized).toBe(47);
+    expect(result.reason).not.toBeNull();
+    expect(result.reason).toMatch(/2\/3/);
+  });
+
+  it("penalizes 2 setups at 58% confidence (session #217 post-r029-filter scenario)", () => {
+    const result = applySetupCountPenalty(58, 2, false);
+    expect(result.penalized).toBe(48);
+    expect(result.reason).not.toBeNull();
+  });
+
+  it("does NOT double-penalize already-penalised confidence (≤50% has no setup requirement)", () => {
+    // If confidence was already reduced to 47% by a prior penalty, re-calling
+    // applySetupCountPenalty(47, 2, false) should return no further penalty
+    // because 47 ≤ 50 means minSetups = 0.
+    const result = applySetupCountPenalty(47, 2, false);
+    expect(result.penalized).toBe(47);
+    expect(result.reason).toBeNull();
+  });
 });
 
 // ── r031: confidence cap enforcement ─────────────────────────


### PR DESCRIPTION
## Summary

Confidence was computed inside `runOracleAnalysis()` using the **pre-filter** setup count, then `filterNonCompliantSetups()` and `filterR036Setups()` in `runAndValidateOracle()` removed setups without recomputing confidence.

After both filters, `applySetupCountPenalty()` is now re-called on the already-penalised confidence with the post-filter setup count. This is safe:
- Same count → same threshold → no extra penalty
- Count dropped below threshold → correct new penalty fires
- Already-penalised confidence ≤50% → `minSetups=0` → no double-penalty

## Root cause confirmed (sessions #217, #222)

Session #222: ORACLE produced NASDAQ + DAX + Crude Oil (3 setups). `computeOracleConfidence(57, 3)` → no penalty (3 meets 3-required threshold). `filterNonCompliantSetups` removed Oil (0.82% stop, oil moved 3.6%). 2 setups remained, confidence stayed at 57% instead of 47%.

## Test plan

- [x] `applySetupCountPenalty(57, 2, false)` → 47% (session #222 scenario)
- [x] `applySetupCountPenalty(58, 2, false)` → 48% (session #217 scenario)
- [x] `applySetupCountPenalty(47, 2, false)` → 47%, no reason (no double-penalty at ≤50%)
- [x] All 751 tests pass (no regressions)